### PR TITLE
Prepare to release v0.3.2

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -25,7 +25,7 @@ cargo release --no-publish --no-tag --allow-branch=$BRANCH $VERSION
 
 # Open a PR; once tests pass and reviewers approve, merge to main and come back here for the final step.
 # NOTE: We are here; this PR was created by this step.
-gh pr create --base main --template .github/release_template.md --title "Prepare to release $VERSION"
+gh pr create --base main --body-file .github/release_template.md --title "Prepare to release $VERSION"
 
 # Finally, run `cargo release` on the main branch.
 # This doesn't create new commits; it just tags the commit and pushes the tag.

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,0 +1,35 @@
+## Overview
+
+Prepares to release the version specified in the title.
+Once all checks pass, the release should be good to go.
+
+## Release steps
+
+```shell
+# Choose a version. It should be valid semver.
+# Also, choose a branch name. A good default is `prep/$VERSION`.
+VERSION=<VERSION>
+BRANCH="prep/$VERSION"
+
+# Make a branch for release prep and check it out.
+git checkout -b $BRANCH
+
+# Have cargo-release create the release.
+# This does several things:
+# - Validates that the git index is clean
+# - Updates version numbers in the crates
+# - Generates the changelog using `git-cliff`
+# - Creates a commit with the changes
+# - Pushes the branch to the remote
+cargo release --no-publish --no-tag --allow-branch=$BRANCH $VERSION
+
+# Open a PR; once tests pass and reviewers approve, merge to main and come back here for the final step.
+# NOTE: We are here; this PR was created by this step.
+gh pr create --base main --template .github/release_template.md --title "Prepare to release $VERSION"
+
+# Finally, run `cargo release` on the main branch.
+# This doesn't create new commits; it just tags the commit and pushes the tag.
+git checkout main
+git pull
+cargo release
+```

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -12,12 +12,9 @@ jobs:
         - host: ubuntu-latest
           setup: echo "no setup"
           build: cargo build
-        - host: macos-latest # runs on arm64
-          setup: echo "no setup"
-          build: cargo build
-        - host: macos-12 # runs on x86_64
-          setup: echo "no setup"
-          build: cargo build
+        - host: macos-latest
+          setup: rustup target add aarch64-apple-darwin
+          build: cargo build --target aarch64-apple-darwin && cargo build --target x86_64-apple-darwin
 
     runs-on: ${{ matrix.settings.host }}
     name: test / ${{ matrix.settings.host }}

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -12,9 +12,12 @@ jobs:
         - host: ubuntu-latest
           setup: echo "no setup"
           build: cargo build
-        - host: macos-latest
-          setup: rustup target add aarch64-apple-darwin
-          build: cargo build --target aarch64-apple-darwin && cargo build --target x86_64-apple-darwin
+        - host: macos-latest # runs on arm64
+          setup: echo "no setup"
+          build: cargo build
+        - host: macos-12 # runs on x86_64
+          setup: echo "no setup"
+          build: cargo build
 
     runs-on: ${{ matrix.settings.host }}
     name: test / ${{ matrix.settings.host }}

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -13,8 +13,12 @@ jobs:
           setup: echo "no setup"
           build: cargo build
         - host: macos-latest
-          setup: rustup target add aarch64-apple-darwin
-          build: cargo build --target aarch64-apple-darwin && cargo build --target x86_64-apple-darwin
+          setup: |
+            rustup target add aarch64-apple-darwin
+            rustup target add x86_64-apple-darwin
+          build: |
+            cargo build --target aarch64-apple-darwin
+            cargo build --target x86_64-apple-darwin
 
     runs-on: ${{ matrix.settings.host }}
     name: test / ${{ matrix.settings.host }}

--- a/.github/workflows/check-static.yml
+++ b/.github/workflows/check-static.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
 
     - run: cargo fmt --all -- --check
-    - run: cargo clippy --all-features --all --tests -- -D clippy::all
+    - run: cargo clippy --all-features --all --tests -- -D clippy::correctness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 _Released: 2024-12-13_
 
+### 🐛 Bug Fixes
+
+- *(circe)* Make viewable by `dist`
+
+### 📚 Documentation
+
+- Add release process
+
+## [v0.3.2](https://github.com/fossas/circe/releases/tag/v0.3.2)
+
 ### ✨ General
 
 - Support `--layers squash-other`, add colors to clap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _Released: 2024-12-14_
 
 - Changelog fixup
 - *(ci)* Fix clippy checks
+- *(ci)* Split macOS test runners by architecture
 
 ## [v0.3.1](https://github.com/fossas/circe/releases/tag/v0.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.3.2](https://github.com/fossas/circe/releases/tag/0.3.2)
 
-_Released: 2024-12-13_
+_Released: 2024-12-14_
 
 ### 🐛 Bug Fixes
 
@@ -21,6 +21,7 @@ _Released: 2024-12-13_
 ### ⚙️ Miscellaneous Tasks
 
 - Changelog fixup
+- *(ci)* Fix clippy checks
 
 ## [v0.3.1](https://github.com/fossas/circe/releases/tag/v0.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ fix tests
 - Support `--layers squash-other`, add colors to clap
 - Ensure crates are not published to crates.io
 - Configure for `cargo release`
+- Revert "chore(ci): split macOS test runners by architecture"
+
+This reverts commit 5f0def95e2b20c40071de1e6b151f801eb0bc984.
 
 ### 📚 Documentation
 
@@ -26,6 +29,7 @@ fix tests
 - Changelog fixup
 - *(ci)* Fix clippy checks
 - *(ci)* Split macOS test runners by architecture
+- *(ci)* Fix macOS test runners
 
 ## [v0.3.1](https://github.com/fossas/circe/releases/tag/v0.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Released: 2024-12-14_
 - Fix(tests):
 rename `compute_relative` -> `compute_symlink_target`
 fix tests
+- *(tests)* Doctest import paths
 
 ### ✨ General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ _Released: 2024-12-14_
 ### 🐛 Bug Fixes
 
 - *(circe)* Make viewable by `dist`
+- Fix(tests):
+rename `compute_relative` -> `compute_symlink_target`
+fix tests
 
 ### ✨ General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,19 @@ _Released: 2024-12-13_
 
 - *(circe)* Make viewable by `dist`
 
-### 📚 Documentation
-
-- Add release process
-
-## [v0.3.2](https://github.com/fossas/circe/releases/tag/v0.3.2)
-
 ### ✨ General
 
 - Support `--layers squash-other`, add colors to clap
 - Ensure crates are not published to crates.io
 - Configure for `cargo release`
+
+### 📚 Documentation
+
+- Add release process
+
+### ⚙️ Miscellaneous Tasks
+
+- Changelog fixup
 
 ## [v0.3.1](https://github.com/fossas/circe/releases/tag/v0.3.1)
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["command-line-utilities", "development-tools"]
 default-run = "circe"
 publish = false
 
+[package.metadata.dist]
+dist = true
+
 [dependencies]
 clap = { version = "4.5.23", features = ["color", "derive"] }
 color-eyre = "0.6.3"

--- a/cliff.toml
+++ b/cliff.toml
@@ -50,7 +50,7 @@ commit_parsers = [
   { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
   { message = "^style", group = "<!-- 5 -->🎨 Styling" },
   { message = "^test", group = "<!-- 6 -->🧪 Testing" },
-  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "(?i)^chore.*release.*", skip = true },
   { message = "^chore\\(deps.*\\)", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -86,7 +86,7 @@ cargo release --no-publish --no-tag --allow-branch=$BRANCH $VERSION
 
 # Open a PR; once tests pass and reviewers approve, merge to main and come back here for the final step.
 # NOTE: We are here; this PR was created by this step.
-gh pr create --base main --template .github/release_template.md --title "Prepare to release $VERSION"
+gh pr create --base main --body-file .github/release_template.md --title "Prepare to release $VERSION"
 
 # Finally, run `cargo release` on the main branch.
 # This doesn't create new commits; it just tags the commit and pushes the tag.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -52,7 +52,7 @@ impl Authentication {
 /// Docker's platform string format (e.g. "linux/amd64").
 ///
 /// ```
-/// # use circe::Platform;
+/// # use circe_lib::Platform;
 /// # use std::str::FromStr;
 /// let platform = Platform::from_str("linux/amd64").expect("parse platform");
 /// assert_eq!(platform.to_string(), "linux/amd64");
@@ -221,14 +221,14 @@ impl std::fmt::Display for Platform {
 
 /// Create a [`Digest`] from a hex string at compile time.
 /// ```
-/// let digest = circe::digest!("sha256", "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
+/// let digest = circe_lib::digest!("sha256", "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
 /// assert_eq!(digest.algorithm, "sha256");
 /// assert_eq!(digest.as_hex(), "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
 /// ```
 ///
 /// If algorithm is not provided, it defaults to [`Digest::SHA256`].
 /// ```
-/// let digest = circe::digest!("a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
+/// let digest = circe_lib::digest!("a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
 /// assert_eq!(digest.algorithm, "sha256");
 /// assert_eq!(digest.as_hex(), "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
 /// ```
@@ -236,22 +236,22 @@ impl std::fmt::Display for Platform {
 /// This macro currently assumes that the hash is 32 bytes long.
 /// Providing a value of a different length will result in a compile-time error.
 /// ```compile_fail
-/// let digest = circe::digest!("a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4deadbeef");
+/// let digest = circe_lib::digest!("a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4deadbeef");
 /// ```
 ///
 /// You can work around this by providing the size of the hash as a third argument.
 /// ```
-/// let digest = circe::digest!(circe::Digest::SHA256, "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4deadbeef", 36);
+/// let digest = circe_lib::digest!(circe_lib::Digest::SHA256, "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4deadbeef", 36);
 /// assert_eq!(digest.algorithm, "sha256");
 /// assert_eq!(digest.as_hex(), "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4deadbeef");
 /// ```
 #[macro_export]
 macro_rules! digest {
     ($hex:expr) => {{
-        circe::digest!(circe::Digest::SHA256, $hex, 32)
+        circe_lib::digest!(circe_lib::Digest::SHA256, $hex, 32)
     }};
     ($algorithm:expr, $hex:expr) => {{
-        circe::digest!($algorithm, $hex, 32)
+        circe_lib::digest!($algorithm, $hex, 32)
     }};
     ($algorithm:expr, $hex:expr, $size:expr) => {{
         const HASH: [u8; $size] = hex_magic::hex!($hex);
@@ -271,7 +271,7 @@ macro_rules! digest {
 ///
 /// ```
 /// # use std::str::FromStr;
-/// let digest = circe::Digest::from_str("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").expect("parse digest");
+/// let digest = circe_lib::Digest::from_str("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").expect("parse digest");
 /// assert_eq!(digest.algorithm, "sha256");
 /// assert_eq!(digest.as_hex(), "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
 /// ```
@@ -336,7 +336,7 @@ impl From<&Digest> for Digest {
 /// This can be a named tag or a SHA256 digest.
 ///
 /// ```
-/// # use circe::{Version, Digest};
+/// # use circe_lib::{Version, Digest};
 /// # use std::str::FromStr;
 /// assert_eq!(Version::latest().to_string(), "latest");
 /// assert_eq!(Version::tag("other").to_string(), "other");
@@ -357,7 +357,7 @@ impl Version {
     /// Returns the tag for "latest".
     ///
     /// ```
-    /// # use circe::Version;
+    /// # use circe_lib::Version;
     /// assert_eq!(Version::latest().to_string(), "latest");
     /// ```
     pub fn latest() -> Self {
@@ -367,7 +367,7 @@ impl Version {
     /// Create a tagged instance.
     ///
     /// ```
-    /// # use circe::Version;
+    /// # use circe_lib::Version;
     /// assert_eq!(Version::tag("latest").to_string(), "latest");
     /// ```
     pub fn tag(tag: &str) -> Self {
@@ -377,8 +377,8 @@ impl Version {
     /// Create a digest instance.
     ///
     /// ```
-    /// # use circe::Version;
-    /// let digest = circe::digest!("sha256", "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
+    /// # use circe_lib::Version;
+    /// let digest = circe_lib::digest!("sha256", "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
     /// let version = Version::digest(digest);
     /// assert_eq!(version.to_string(), "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");
     /// ```
@@ -390,7 +390,7 @@ impl Version {
 /// A parsed container image reference.
 ///
 /// ```
-/// # use circe::{Reference, Version};
+/// # use circe_lib::{Reference, Version};
 /// # use std::str::FromStr;
 /// // Default to latest tag
 /// let reference = Reference::from_str("docker.io/library/ubuntu").expect("parse reference");

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -173,7 +173,7 @@ impl FromStr for Platform {
                 .header("Expected:")
         };
         let examples_section = || {
-            vec!["linux/amd64/v7", "darwin/arm64"]
+            ["linux/amd64/v7", "darwin/arm64"]
                 .join("\n")
                 .header("Examples:")
         };

--- a/release.toml
+++ b/release.toml
@@ -1,2 +1,4 @@
 sign-tag = true
 sign-commit = true
+pre-release-commit-message = "chore: Release {{version}}"
+tag-message	= "chore: Release {{version}}"


### PR DESCRIPTION
## Overview

Prepares to release the version specified in the title.
Once all checks pass, the release should be good to go.

## Release steps

```shell
# Choose a version. It should be valid semver.
# Also, choose a branch name. A good default is `prep/$VERSION`.
VERSION=<VERSION>
BRANCH="prep/$VERSION"

# Make a branch for release prep and check it out.
git checkout -b $BRANCH

# Have cargo-release create the release.
# This does several things:
# - Validates that the git index is clean
# - Updates version numbers in the crates
# - Generates the changelog using `git-cliff`
# - Creates a commit with the changes
# - Pushes the branch to the remote
cargo release --no-publish --no-tag --allow-branch=$BRANCH $VERSION

# Open a PR; once tests pass and reviewers approve, merge to main and come back here for the final step.
# NOTE: We are here; this PR was created by this step.
gh pr create --base main --template release_template --title "Prepare to release $VERSION"

# Finally, run `cargo release` on the main branch.
# This doesn't create new commits; it just tags the commit and pushes the tag.
git checkout main
git pull
cargo release
```
