### PR TITLE
chore(ci): faster builds

### DIFF
--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -2,48 +2,52 @@ name: dynamic
 on: pull_request
 
 jobs:
-  check-build:
+  check-test:
     strategy:
       matrix:
         settings:
         - host: windows-latest
+          target: x86_64-pc-windows-gnu
         - host: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+        - host: macos-latest
+          target: aarch64-apple-darwin
+        - host: macos-latest
+          target: x86_64-apple-darwin
 
     runs-on: ${{ matrix.settings.host }}
-    name: test / ${{ matrix.settings.host }}
+    name: test / ${{ matrix.settings.host }} / ${{ matrix.settings.target }}
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2.7.5
       with:
-        key: ${{ matrix.settings.host }}
-    - uses: sambacha/parallelish@v1.0.0
-      id: tasks
-      with:
-        cmd1: cargo build
-        cmd2: cargo check --release --all --bins --examples --tests
-        cmd3: cargo nextest run --all-targets
-        cmd4: cargo test --doc
+        key: test_${{ matrix.settings.host }}_${{ matrix.settings.target }}
+    - run: cargo nextest run --all-targets
+    - run: cargo test --doc
 
-  check-macos:
-    runs-on: macos-latest
-    name: test / macos-latest
+  check-build:
+    strategy:
+      matrix:
+        settings:
+        - host: windows-latest
+          target: x86_64-pc-windows-gnu
+        - host: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+        - host: macos-latest
+          target: aarch64-apple-darwin
+        - host: macos-latest
+          target: x86_64-apple-darwin
+
+    runs-on: ${{ matrix.settings.host }}
+    name: build / ${{ matrix.settings.host }} / ${{ matrix.settings.target }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
-        targets: aarch64-apple-darwin,x86_64-apple-darwin
+    - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2.7.5
       with:
-        key: macos-latest
-    - uses: sambacha/parallelish@v1.0.0
-      id: tasks
-      with:
-        cmd1: cargo build --target x86_64-apple-darwin
-        cmd2: cargo build --target aarch64-apple-darwin
-        cmd3: cargo check --release --all --bins --examples --tests
-        cmd4: cargo nextest run --all-targets
-        cmd5: cargo test --doc
+        key: build_${{ matrix.settings.host }}_${{ matrix.settings.target }}
+    - run: cargo check --all --bins --examples --tests
+    - run: cargo build

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -55,6 +55,7 @@ jobs:
     name: build / ${{ matrix.settings.host }} / ${{ matrix.settings.target }}
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
         targets: ${{ matrix.settings.target }}

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2.7.5
       with:
         key: ${{ matrix.settings.host }}
-    - uses: sambacha/parallelish@v1
+    - uses: sambacha/parallelish@v1.0.0
       id: tasks
       with:
         cmd1: cargo build
@@ -39,7 +39,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2.7.5
       with:
         key: macos-latest
-    - uses: sambacha/parallelish@v1
+    - uses: sambacha/parallelish@v1.0.0
       id: tasks
       with:
         cmd1: cargo build --target x86_64-apple-darwin

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -19,7 +19,10 @@ jobs:
     name: test / ${{ matrix.settings.host }} / ${{ matrix.settings.target }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        targets: ${{ matrix.settings.target }}
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2.7.5
       with:
@@ -44,8 +47,9 @@ jobs:
     name: build / ${{ matrix.settings.host }} / ${{ matrix.settings.target }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: taiki-e/install-action@nextest
+      with:
+        toolchain: stable
+        targets: ${{ matrix.settings.target }}
     - uses: Swatinem/rust-cache@v2.7.5
       with:
         key: build_${{ matrix.settings.host }}_${{ matrix.settings.target }}

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -7,18 +7,7 @@ jobs:
       matrix:
         settings:
         - host: windows-latest
-          setup: echo "no setup"
-          build: cargo build
         - host: ubuntu-latest
-          setup: echo "no setup"
-          build: cargo build
-        - host: macos-latest
-          setup: |
-            rustup target add aarch64-apple-darwin
-            rustup target add x86_64-apple-darwin
-          build: |
-            cargo build --target aarch64-apple-darwin
-            cargo build --target x86_64-apple-darwin
 
     runs-on: ${{ matrix.settings.host }}
     name: test / ${{ matrix.settings.host }}
@@ -29,8 +18,32 @@ jobs:
     - uses: Swatinem/rust-cache@v2.7.5
       with:
         key: ${{ matrix.settings.host }}
-    - run: ${{ matrix.settings.setup }}
-    - run: ${{ matrix.settings.build }}
-    - run: cargo check --release --all --bins --examples --tests
-    - run: cargo nextest run --all-targets
-    - run: cargo test --doc
+    - uses: sambacha/parallelish@v1
+      id: tasks
+      with:
+        cmd1: cargo build
+        cmd2: cargo check --release --all --bins --examples --tests
+        cmd3: cargo nextest run --all-targets
+        cmd4: cargo test --doc
+
+  check-macos:
+    runs-on: macos-latest
+    name: test / macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        targets: aarch64-apple-darwin,x86_64-apple-darwin
+    - uses: taiki-e/install-action@nextest
+    - uses: Swatinem/rust-cache@v2.7.5
+      with:
+        key: macos-latest
+    - uses: sambacha/parallelish@v1
+      id: tasks
+      with:
+        cmd1: cargo build --target x86_64-apple-darwin
+        cmd2: cargo build --target aarch64-apple-darwin
+        cmd3: cargo check --release --all --bins --examples --tests
+        cmd4: cargo nextest run --all-targets
+        cmd5: cargo test --doc

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -7,9 +7,13 @@ jobs:
       matrix:
         settings:
         - host: windows-latest
-          target: x86_64-pc-windows-gnu
+          target: x86_64-pc-windows-msvc
         - host: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+        - host: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+        - host: ubuntu-latest
+          target: x86_64-unknown-linux-musl
         - host: macos-latest
           target: aarch64-apple-darwin
         - host: macos-latest
@@ -35,9 +39,13 @@ jobs:
       matrix:
         settings:
         - host: windows-latest
-          target: x86_64-pc-windows-gnu
+          target: x86_64-pc-windows-msvc
         - host: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+        - host: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+        - host: ubuntu-latest
+          target: x86_64-unknown-linux-musl
         - host: macos-latest
           target: aarch64-apple-darwin
         - host: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.25.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.26.1/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -107,6 +107,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -117,8 +118,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
-        run: ${{ matrix.install_dist }}
+        run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@v4
@@ -143,7 +151,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.3.3](https://github.com/fossas/circe/releases/tag/0.3.3)
+## [v0.3.3](https://github.com/fossas/circe/releases/tag/v0.3.3)
 
 _Released: 2024-12-14_
 

--- a/bin/release.toml
+++ b/bin/release.toml
@@ -1,3 +1,3 @@
 tag-prefix = ""
 shared-version = true
-pre-release-hook = ["git", "cliff", "--workdir", "..", "-o", "../CHANGELOG.md", "--tag", "{{version}}" ]
+pre-release-hook = ["git", "cliff", "--workdir", "..", "--tag", "{{version}}" ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -29,8 +29,6 @@ footer = """
 """
 
 trim = true
-
-render_always = true
 output = "CHANGELOG.md"
 
 [git]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,13 +4,13 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.25.1"
+cargo-dist-version = "0.26.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "~/.circe/bin"
 # Whether to install an updater program

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -63,6 +63,14 @@ if this is not realistic at minimum every non-bugfix release **must** ensure dep
 > [!TIP]
 > Requires `cargo-release` and `git-cliff` to be installed.
 
+> [!NOTE]
+> In order to have your changes integrate with the changelog,
+> make sure to merge commits to `main` with a meaningful commit message.
+>
+> Additionally, if those commits are parseable as [conventional commits](https://www.conventionalcommits.org),
+> they will be grouped into sections in the changelog.
+> See the `cliff.toml` file for more details and group examples.
+
 Use `cargo release` to create a release.
 Since we cannot push to `main` directly, perform the steps below:
 


### PR DESCRIPTION
# Overview

Makes builds in CI faster by concurrently running the `cargo build`, `cargo check`, and `cargo test` commands.

## Acceptance criteria

CI is faster, nothing breaks

## Testing plan

Manual review of CI and CI times

## Metrics

None

## Risks

No major risk

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
