### PR TITLE
feat: Support docker-like references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ powershell -c "irm https://github.com/fossas/circe/releases/latest/download/circ
 > [!TIP]
 > Check the help output for more details.
 
-## extract
+## subcommand: extract
 
 Extracts the contents of the image to disk.
 
@@ -50,7 +50,7 @@ Extracts the contents of the image to disk.
 #
 # Arguments:
 #   <image>
-#       The image to extract.
+#       The image to extract. See image reference below for more details.
 #   <target>
 #       The directory to which the image is extracted.
 #
@@ -84,7 +84,7 @@ Extracts the contents of the image to disk.
 circe extract docker.io/contribsys/faktory:latest ./faktory --layers squash --platform linux/amd64
 ```
 
-## list
+## subcommand:list
 
 Lists the contents of an image.
 
@@ -96,7 +96,7 @@ Lists the contents of an image.
 #
 # Arguments:
 #   <image>
-#       The image to list.
+#       The image to list. See image reference below for more details.
 #
 # Options for `circe list`:
 #   --platform
@@ -108,6 +108,71 @@ Lists the contents of an image.
 #       The password to use for authentication; "username" is also required if provided.
 circe list docker.io/contribsys/faktory:latest
 ```
+
+## image reference
+
+The primary recommendation for referencing an image is to use the fully qualified reference, e.g.:
+
+```shell
+docker.io/contribsys/faktory:latest
+docker.io/library/ubuntu:14.04
+some-host.dev/some-namespace/some-project/some-image:latest
+some-host.dev/some-namespace/some-project/some-image@sha256:123abc
+```
+
+However, for convenience, you can specify a "partial image reference" in a few different ways:
+
+```shell
+# namespace + name + tag; infers to docker.io/contribsys/faktory:latest
+circe list contribsys/faktory:latest
+
+# namespace + name + digest; infers to docker.io/contribsys/faktory@sha256:123abc
+circe list contribsys/faktory@sha256:123abc
+
+# namespace + name; infers to docker.io/contribsys/faktory:latest
+circe list contribsys/faktory
+
+# name + tag; infers to docker.io/library/ubuntu:latest
+circe list ubuntu:latest
+
+# name + digest; infers to docker.io/library/ubuntu@sha256:123abc
+circe list ubuntu@sha256:123abc
+
+# name; infers to docker.io/library/ubuntu:latest
+circe list ubuntu
+```
+
+By default, `circe` fills in `docker.io` for the registry and `library` for the namespace.
+However, you can customize the registry and namespace by setting the `OCI_BASE` and `OCI_NAMESPACE` environment variables:
+
+```shell
+# Specify the registry and/or namespace:
+export OCI_BASE=some-host.dev
+export OCI_NAMESPACE=some-namespace
+
+# namespace + name + tag; infers to some-host.dev/contribsys/faktory:latest
+circe list contribsys/faktory:latest
+
+# namespace + name + digest; infers to some-host.dev/contribsys/faktory@sha256:123abc
+circe list contribsys/faktory@sha256:123abc
+
+# namespace + name; infers to some-host.dev/contribsys/faktory:latest
+circe list contribsys/faktory
+
+# name + tag; infers to some-host.dev/some-namespace/ubuntu:latest
+circe list ubuntu:latest
+
+# name + digest; infers to some-host.dev/some-namespace/ubuntu@sha256:123abc
+circe list ubuntu@sha256:123abc
+
+# name; infers to some-host.dev/some-namespace/ubuntu:latest
+circe list ubuntu
+```
+
+**The overall recommendation is to use fully qualified references.**
+The intention with the ability to override `OCI_BASE` and `OCI_NAMESPACE` is to make setup easier for CI/CD pipelines
+that need to extract multiple images from a custom host and/or namespace, but don't want to have to write scripts
+to concatenate them into fully qualified references.
 
 ## platform selection
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ circe list docker.io/contribsys/faktory:latest
 The primary recommendation for referencing an image is to use the fully qualified reference, e.g.:
 
 ```shell
-docker.io/contribsys/faktory:latest
-docker.io/library/ubuntu:14.04
-some-host.dev/some-namespace/some-project/some-image:latest
-some-host.dev/some-namespace/some-project/some-image@sha256:123abc
+circe list docker.io/contribsys/faktory:latest
+circe list docker.io/library/ubuntu:14.04
+circe list some-host.dev/some-namespace/some-project/some-image:latest
+circe list some-host.dev/some-namespace/some-project/some-image@sha256:123abc
 ```
 
 However, for convenience, you can specify a "partial image reference" in a few different ways:

--- a/bin/src/list.rs
+++ b/bin/src/list.rs
@@ -1,9 +1,9 @@
-use circe_lib::{registry::Registry, Authentication};
+use circe_lib::{registry::Registry, Authentication, Reference};
 use clap::Parser;
 use color_eyre::eyre::{Context, Result};
 use derive_more::Debug;
 use pluralizer::pluralize;
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 use tracing::{debug, info};
 
 use crate::extract::Target;
@@ -19,13 +19,15 @@ pub struct Options {
 pub async fn main(opts: Options) -> Result<()> {
     info!("extracting image");
 
+    let reference = Reference::from_str(&opts.target.image)?;
     let auth = match (opts.target.username, opts.target.password) {
         (Some(username), Some(password)) => Authentication::basic(username, password),
         _ => Authentication::default(),
     };
+
     let registry = Registry::builder()
         .maybe_platform(opts.target.platform)
-        .reference(opts.target.image)
+        .reference(reference)
         .auth(auth)
         .build()
         .await

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
                 .with_deferred_spans(true)
                 .with_bracketed_fields(true)
                 .with_span_retrace(true)
-                .with_targets(true),
+                .with_targets(false),
         )
         .with(
             tracing_subscriber::EnvFilter::builder()

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use std::{borrow::Cow, ops::Add, str::FromStr};
 use strum::{AsRefStr, EnumIter, IntoEnumIterator};
 use tap::{Pipe, Tap};
-use tracing::debug;
+use tracing::{debug, warn};
 
 mod ext;
 pub mod registry;
@@ -450,6 +450,7 @@ impl FromStr for Reference {
             // For docker compatibility, `{name}` is parsed as `docker.io/library/{name}`.
             [name] => {
                 let (name, version) = parse_name(name)?;
+                warn!("expanding '{name}' to '{DOCKER_IO}/{LIBRARY}/{name}'; fully specify the reference to avoid this behavior");
                 (DOCKER_IO, LIBRARY, name, version)
             }
 
@@ -457,10 +458,12 @@ impl FromStr for Reference {
             // This is a special case for docker compatibility.
             [host, name] if *host == DOCKER_IO => {
                 let (name, version) = parse_name(name)?;
+                warn!("expanding '{host}/{name}' to '{host}/{LIBRARY}/{name}'; fully specify the reference to avoid this behavior");
                 (*host, LIBRARY, name, version)
             }
             [namespace, name] => {
                 let (name, version) = parse_name(name)?;
+                warn!("expanding '{namespace}/{name}' to '{DOCKER_IO}/{namespace}/{name}'; fully specify the reference to avoid this behavior");
                 (DOCKER_IO, *namespace, name, version)
             }
 

--- a/lib/tests/it/reference.rs
+++ b/lib/tests/it/reference.rs
@@ -20,7 +20,25 @@ fn display(reference: Reference, expected: &str) {
     pretty_assertions::assert_eq!(reference.to_string(), expected);
 }
 
-#[test_case("invalid:latest"; "invalid:latest")]
+#[test_case("ubuntu", "docker.io/library/ubuntu:latest"; "ubuntu")]
+#[test_case("ubuntu:14.04", "docker.io/library/ubuntu:14.04"; "ubuntu:14.04")]
+#[test_case("ubuntu@sha256:123abc", "docker.io/library/ubuntu@sha256:123abc"; "ubuntu@sha256:123abc")]
+#[test_case("library/ubuntu", "docker.io/library/ubuntu:latest"; "library/ubuntu")]
+#[test_case("contribsys/faktory", "docker.io/contribsys/faktory:latest"; "contribsys/faktory")]
+#[test_case("contribsys/faktory:1.0.0", "docker.io/contribsys/faktory:1.0.0"; "contribsys/faktory:1.0.0")]
+#[test_case("library/ubuntu:14.04", "docker.io/library/ubuntu:14.04"; "library/ubuntu:14.04")]
+#[test_case("library/ubuntu@sha256:123abc", "docker.io/library/ubuntu@sha256:123abc"; "library/ubuntu@sha256:123abc")]
+#[test_case("docker.io/library/ubuntu:14.04", "docker.io/library/ubuntu:14.04"; "docker.io/library/ubuntu:14.04")]
+#[test_case("docker.io/library/ubuntu@sha256:123abc", "docker.io/library/ubuntu@sha256:123abc"; "docker.io/library/ubuntu@sha256:123abc")]
+#[test_case("host.dev/somecorp/someproject/someimage", "host.dev/somecorp/someproject/someimage:latest"; "host.dev/somecorp/someproject/someimage")]
+#[test_case("host.dev/somecorp/someproject/someimage:1.0.0", "host.dev/somecorp/someproject/someimage:1.0.0"; "host.dev/somecorp/someproject/someimage:1.0.0")]
+#[test_case("host.dev/somecorp/someproject/someimage@sha256:123abc", "host.dev/somecorp/someproject/someimage@sha256:123abc"; "host.dev/somecorp/someproject/someimage@sha256:123abc")]
+#[test]
+fn docker_like(input: &str, expected: &str) {
+    let reference = input.parse::<Reference>().unwrap();
+    pretty_assertions::assert_eq!(reference.to_string(), expected);
+}
+
 #[test_case("/repo:tag"; "/repo:tag")]
 #[test_case("host/:tag"; "host/tag")]
 #[test_case("host/"; "host/")]

--- a/lib/tests/it/reference.rs
+++ b/lib/tests/it/reference.rs
@@ -39,6 +39,27 @@ fn docker_like(input: &str, expected: &str) {
     pretty_assertions::assert_eq!(reference.to_string(), expected);
 }
 
+#[test_case("ubuntu", "host.dev/somecorp/someproject/ubuntu:latest"; "ubuntu")]
+#[test_case("ubuntu:14.04", "host.dev/somecorp/someproject/ubuntu:14.04"; "ubuntu:14.04")]
+#[test_case("ubuntu@sha256:123abc", "host.dev/somecorp/someproject/ubuntu@sha256:123abc"; "ubuntu@sha256:123abc")]
+#[test_case("library/ubuntu", "host.dev/library/ubuntu:latest"; "library/ubuntu")]
+#[test_case("contribsys/faktory", "host.dev/contribsys/faktory:latest"; "contribsys/faktory")]
+#[test_case("contribsys/faktory:1.0.0", "host.dev/contribsys/faktory:1.0.0"; "contribsys/faktory:1.0.0")]
+#[test_case("library/ubuntu:14.04", "host.dev/library/ubuntu:14.04"; "library/ubuntu:14.04")]
+#[test_case("library/ubuntu@sha256:123abc", "host.dev/library/ubuntu@sha256:123abc"; "library/ubuntu@sha256:123abc")]
+#[test_case("docker.io/library/ubuntu:14.04", "docker.io/library/ubuntu:14.04"; "docker.io/library/ubuntu:14.04")]
+#[test_case("docker.io/library/ubuntu@sha256:123abc", "docker.io/library/ubuntu@sha256:123abc"; "docker.io/library/ubuntu@sha256:123abc")]
+#[test_case("host.dev/somecorp/someproject/someimage", "host.dev/somecorp/someproject/someimage:latest"; "host.dev/somecorp/someproject/someimage")]
+#[test_case("host.dev/somecorp/someproject/someimage:1.0.0", "host.dev/somecorp/someproject/someimage:1.0.0"; "host.dev/somecorp/someproject/someimage:1.0.0")]
+#[test_case("host.dev/somecorp/someproject/someimage@sha256:123abc", "host.dev/somecorp/someproject/someimage@sha256:123abc"; "host.dev/somecorp/someproject/someimage@sha256:123abc")]
+#[test]
+fn docker_like_custom_base_namespace(input: &str, expected: &str) {
+    std::env::set_var(circe_lib::OCI_BASE_VAR, "host.dev");
+    std::env::set_var(circe_lib::OCI_NAMESPACE_VAR, "somecorp/someproject");
+    let reference = input.parse::<Reference>().unwrap();
+    pretty_assertions::assert_eq!(reference.to_string(), expected);
+}
+
 #[test_case("/repo:tag"; "/repo:tag")]
 #[test_case("host/:tag"; "host/tag")]
 #[test_case("host/"; "host/")]


### PR DESCRIPTION
# Overview

Adds support for docker-like references.
The following all work:
```shell
docker pull ubuntu
docker pull contribsys/faktory
docker pull docker.io/ubuntu
docker pull library/ubuntu
```

Previously, `circe` would error on these cases; now it doesn't, and works as you'd expect.
In effect, partially-qualified references are expanded to `docker.io/library/{name}` by default.

The choice of `docker.io` being the default was chosen mainly for compatibility with the behavior in FOSSA CLI. I considered adding more hosts, but decided it'd be better to push users to fully qualify their references instead of having them lean on potentially surprising fallback behavior.

## Acceptance criteria

Docker-style pulls are possible.

## Testing plan

Automated tests cover this mostly; did some basic manual tests below:
```shell
; cargo run -- extract contribsys/faktory scratch --overwrite
   Compiling circe_lib v0.3.3 (/Users/jess/projects/circe/lib)
   Compiling circe v0.3.3 (/Users/jess/projects/circe/bin)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.52s
     Running `target/debug/circe extract contribsys/faktory scratch --overwrite`
┐main{opts=Options { target: Target { image: "contribsys/faktory", platform: None, username: None, .. }, output_dir: "scratch", overwrite: true, layers: Squash, layer_glob: None, file_glob: None, layer_regex: None, file_regex: None }}
├─  INFO extracting image
├─  WARN expanding 'contribsys/faktory' to 'docker.io/contribsys/faktory'; fully specify the reference to avoid this behavior
├─  INFO removing existing output directory, path="/Users/jess/projects/circe/scratch"
├─  INFO enumerated 6 layers
├─  INFO applying layer 1 of 6, layer=sha256:cf04c63912e16506c4413937c7f4579018e4bb25c272d989789cfba77b12f951
├─  INFO applying layer 2 of 6, layer=sha256:c7d295e5ea131404d7daad6c665c069eaca393373338ad18a14b90556f0540f5
├─  INFO applying layer 3 of 6, layer=sha256:6fbf45066bb4f8b01361714c3110fa6963bc3b5a7b1e525802f204283a3b20b4
├─  INFO applying layer 4 of 6, layer=sha256:1704d03cf7438aa26afa5705246511247b3530b64ff596114aea2a5ac7bd7ef0
├─  INFO applying layer 5 of 6, layer=sha256:f5a817431cb3b1f5362e01b289f7989be55e37b9e9baaec262263078eedf7676
├─  INFO applying layer 6 of 6, layer=sha256:a124f83435a22b4e87a7d4e544a7f0b3273e06d196c181cc3b1b7945961640d1
├─  INFO finished applying layers
┘
```

```shell
; cargo run -- extract ubuntu scratch --overwrite                            
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/circe extract ubuntu scratch --overwrite`
┐main{opts=Options { target: Target { image: "ubuntu", platform: None, username: None, .. }, output_dir: "scratch", overwrite: true, layers: Squash, layer_glob: None, file_glob: None, layer_regex: None, file_regex: None }}
├─  INFO extracting image
├─  WARN expanding 'ubuntu' to 'docker.io/library/ubuntu'; fully specify the reference to avoid this behavior
├─  INFO removing existing output directory, path="/Users/jess/projects/circe/scratch"
├─  INFO enumerated 1 layer
├─  INFO applying layer 1 of 1, layer=sha256:8bb55f0677778c3027fcc4253dc452bc9c22de989a696391e739fb1cdbbdb4c2
├─  INFO finished applying layers
┘
```

```shell
; cargo run -- extract docker.io/ubuntu scratch --overwrite
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/circe extract docker.io/ubuntu scratch --overwrite`
┐main{opts=Options { target: Target { image: "docker.io/ubuntu", platform: None, username: None, .. }, output_dir: "scratch", overwrite: true, layers: Squash, layer_glob: None, file_glob: None, layer_regex: None, file_regex: None }}
├─  INFO extracting image
├─  WARN expanding 'docker.io/ubuntu' to 'docker.io/library/ubuntu'; fully specify the reference to avoid this behavior
├─  INFO removing existing output directory, path="/Users/jess/projects/circe/scratch"
├─  INFO enumerated 1 layer
├─  INFO applying layer 1 of 1, layer=sha256:8bb55f0677778c3027fcc4253dc452bc9c22de989a696391e739fb1cdbbdb4c2
├─  INFO finished applying layers
┘
```

## Metrics

None

## Risks

Allowing users to provide partially qualified references introduces potential for confusion into the system, but since this is the same behavior as `docker` (with which most container users are familiar) I think this is minimized.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
