### PR TITLE
Support pulling auth from docker config

### DIFF
--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -31,6 +31,17 @@ jobs:
     - uses: Swatinem/rust-cache@v2.7.5
       with:
         key: test_${{ matrix.settings.host }}_${{ matrix.settings.target }}
+    - uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: fossa+sparkle
+        password: ${{ secrets.QUAY_API_KEY }}
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
     - run: cargo nextest run --all-targets
     - run: cargo test --doc
 

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -79,5 +79,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2.7.5
       with:
         key: build_${{ matrix.settings.host }}_${{ matrix.settings.target }}
+
     - run: cargo check --all --bins --examples --tests
     - run: cargo build

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -1,6 +1,10 @@
 name: dynamic
 on: pull_request
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   check-test:
     strategy:

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -36,11 +36,13 @@ jobs:
       with:
         key: test_${{ matrix.settings.host }}_${{ matrix.settings.target }}
     - uses: docker/login-action@v3
+      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
       with:
         registry: quay.io
         username: fossa+sparkle
         password: ${{ secrets.QUAY_API_KEY }}
     - uses: docker/login-action@v3
+      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/bin/src/extract.rs
+++ b/bin/src/extract.rs
@@ -156,7 +156,7 @@ pub async fn main(opts: Options) -> Result<()> {
     let file_regexes = Filters::parse_regex(opts.file_regex.into_iter().flatten())?;
     let auth = match (opts.target.username, opts.target.password) {
         (Some(username), Some(password)) => Authentication::basic(username, password),
-        _ => Authentication::default(),
+        _ => Authentication::docker(&reference).await?,
     };
 
     let output = canonicalize_output_dir(&opts.output_dir, opts.overwrite)?;

--- a/bin/src/list.rs
+++ b/bin/src/list.rs
@@ -22,7 +22,7 @@ pub async fn main(opts: Options) -> Result<()> {
     let reference = Reference::from_str(&opts.target.image)?;
     let auth = match (opts.target.username, opts.target.password) {
         (Some(username), Some(password)) => Authentication::basic(username, password),
-        _ => Authentication::default(),
+        _ => Authentication::docker(&reference).await?,
     };
 
     let registry = Registry::builder()

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 [dependencies]
 async-compression = { version = "0.4.18", features = ["tokio", "gzip", "zstd"] }
 async-tempfile = "0.6.0"
+base64 = "0.22.1"
 bon = "3.3.0"
 bytes = "1.9.0"
 color-eyre = "0.6.3"
@@ -29,6 +30,8 @@ itertools = "0.14.0"
 oci-client = { version = "0.14.0", features = ["rustls-tls"], default-features = false }
 os_str_bytes = "7.0.0"
 regex = "1.11.1"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
 static_assertions = "1.1.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tap = "1.0.1"

--- a/lib/src/docker.rs
+++ b/lib/src/docker.rs
@@ -1,0 +1,180 @@
+use std::{collections::HashMap, process::Stdio};
+
+use crate::{homedir, Authentication, Reference};
+use base64::Engine;
+use color_eyre::{
+    eyre::{eyre, Context, OptionExt, Result},
+    Section, SectionExt,
+};
+use serde::Deserialize;
+use tap::TapFallible;
+use tokio::io::AsyncWriteExt;
+use tracing::{info, warn};
+
+impl Authentication {
+    /// Read authentication information for the host from the configured Docker credentials, if any.
+    ///
+    /// Reference:
+    /// - https://docs.docker.com/reference/cli/docker/login
+    /// - https://github.com/docker/docker-credential-helpers
+    pub async fn docker(target: &Reference) -> Result<Self> {
+        let host = &target.host;
+        let path = homedir()
+            .context("get home directory")?
+            .join(".docker")
+            .join("config.json");
+
+        let config = tokio::fs::read_to_string(&path)
+            .await
+            .context("read docker config")
+            .with_section(|| path.display().to_string().header("Config file path:"))?;
+
+        serde_json::from_str::<DockerConfig>(&config)
+            .context("parse docker config")
+            .with_section(|| path.display().to_string().header("Config file path:"))
+            .with_section(|| config.header("Config file content:"))?
+            .auth(host)
+            .await
+            .tap_ok(|auth| info!("inferred docker auth: {auth:?}"))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DockerConfig {
+    /// The default credential store.
+    ///
+    /// The value of the config property is the suffix of the program to use (i.e. everything after `docker-credential-`).
+    creds_store: Option<String>,
+
+    /// Credential stores per host.
+    ///
+    /// Credential helpers are specified in a similar way to credsStore, but allow for multiple helpers to be configured at a time.
+    /// Keys specify the registry domain, and values specify the suffix of the program to use (i.e. everything after docker-credential-).
+    #[serde(default)]
+    cred_helpers: HashMap<String, String>,
+
+    /// Logged in hosts.
+    #[serde(default)]
+    auths: HashMap<String, DockerAuth>,
+}
+
+impl DockerConfig {
+    /// Some hosts have fallback keys.
+    /// Given a host, this function returns an iterator representing fallback keys to check for authentication.
+    fn auth_keys<'a>(host: &'a str) -> impl Iterator<Item = &'a str> {
+        if host == "docker.io" {
+            vec!["docker.io", "https://index.docker.io/v1/"]
+        } else {
+            vec![host]
+        }
+        .into_iter()
+    }
+
+    /// Returns the auth for the host.
+    ///
+    /// Some hosts have fallback keys; the host that actually was used to retrieve the auth
+    /// is returned so that if it was a fallback key the correct key can be used to
+    /// retrieve auth information in subsequent operations.
+    async fn auth(&self, host: &str) -> Result<Authentication> {
+        for key in Self::auth_keys(host) {
+            if let Some(auth) = self.auths.get(key) {
+                match auth.decode(self, host).await {
+                    Ok(auth) => return Ok(auth),
+                    Err(err) => {
+                        warn!("failed decoding auth for host {key}: {err}");
+                        continue;
+                    }
+                }
+            }
+        }
+
+        Ok(Authentication::None)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum DockerAuth {
+    /// The credentials are stored in plain text, not in a helper.
+    Plain {
+        /// Base64 encoded authentication credentials in the form of `username:password`.
+        auth: String,
+    },
+
+    /// The credentials are stored in a helper.
+    /// Use the host with the top level [`DockerConfig`] to determine which helper to use.
+    Helper {},
+}
+
+impl DockerAuth {
+    async fn decode(&self, config: &DockerConfig, host: &str) -> Result<Authentication> {
+        match self {
+            DockerAuth::Plain { auth } => Self::decode_plain(auth),
+            DockerAuth::Helper {} => Self::decode_helper(config, host).await,
+        }
+    }
+
+    fn decode_plain(auth: &str) -> Result<Authentication> {
+        let auth = base64::engine::general_purpose::STANDARD
+            .decode(&auth)
+            .context("decode base64 auth key")?;
+        let auth = String::from_utf8(auth).context("parse auth key as utf-8")?;
+        let (username, password) = auth
+            .split_once(':')
+            .ok_or_eyre("invalid auth key format, expected username:password")?;
+        Ok(Authentication::basic(username, password))
+    }
+
+    async fn decode_helper(config: &DockerConfig, host: &str) -> Result<Authentication> {
+        let helper = config
+            .cred_helpers
+            .get(host)
+            .or(config.creds_store.as_ref())
+            .ok_or_eyre("no helper found for host")?;
+
+        let binary = format!("docker-credential-{helper}");
+        let mut exec = tokio::process::Command::new(&binary)
+            .arg("get")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("spawn docker credential helper")
+            .with_section(|| binary.clone().header("Helper binary:"))?;
+
+        if let Some(mut stdin) = exec.stdin.take() {
+            stdin
+                .write_all(host.as_bytes())
+                .await
+                .context("write request to helper")?;
+            drop(stdin);
+        }
+
+        let output = exec.wait_with_output().await.context("run helper")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            return Err(eyre!("auth helper failed with status: {}", output.status))
+                .with_section(|| binary.clone().header("Helper binary:"))
+                .with_section(|| output.status.to_string().header("Command status code:"))
+                .with_section(|| stderr.header("Stderr:"))
+                .with_section(|| stdout.header("Stdout:"));
+        }
+
+        let credential = serde_json::from_slice::<DockerCredential>(&output.stdout)
+            .context("decode helper output")
+            .with_section(|| binary.header("Helper binary:"))?;
+        Ok(Authentication::basic(
+            credential.username,
+            credential.secret,
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct DockerCredential {
+    username: String,
+    secret: String,
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -8,11 +8,12 @@ use color_eyre::{
 use derive_more::derive::{Debug, Display, From};
 use enum_assoc::Assoc;
 use itertools::Itertools;
-use std::{borrow::Cow, ops::Add, str::FromStr};
+use std::{borrow::Cow, ops::Add, path::PathBuf, str::FromStr};
 use strum::{AsRefStr, EnumIter, IntoEnumIterator};
 use tap::{Pipe, Tap};
 use tracing::{debug, warn};
 
+mod docker;
 mod ext;
 pub mod registry;
 pub mod transform;
@@ -885,4 +886,13 @@ impl FromStr for Glob {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.to_string().pipe(Self).pipe(Ok)
     }
+}
+
+/// Get the current home directory for the current user.
+///
+/// This is a convenience function for `std::env::var("HOME")` or `std::env::var("USERPROFILE")`.
+fn homedir() -> Result<PathBuf, std::env::VarError> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map(PathBuf::from)
 }

--- a/lib/tests/it/docker.rs
+++ b/lib/tests/it/docker.rs
@@ -1,0 +1,30 @@
+use async_tempfile::TempDir;
+use circe_lib::{registry::Registry, Authentication, Reference};
+use color_eyre::Result;
+use simple_test_case::test_case;
+
+// These tests require that your local docker instance is authenticated with the servers.
+// This is performed before tests are run in CI, but you may need to `docker login` locally.
+#[test_case("quay.io/fossa/hubble-api:latest"; "quay.io/fossa/hubble-api:latest")]
+#[test_case("ghcr.io/fossas/sherlock/server:latest"; "ghcr.io/fossas/sherlock/server:latest")]
+#[test_log::test(tokio::test)]
+async fn pull_authed(image: &str) -> Result<()> {
+    let reference = image.parse::<Reference>()?;
+    let auth = Authentication::docker(&reference).await?;
+    let registry = Registry::builder()
+        .auth(auth)
+        .reference(reference)
+        .build()
+        .await?;
+
+    let layers = registry.layers().await?;
+    assert!(!layers.is_empty(), "image should have at least one layer");
+
+    let tmp = TempDir::new().await?;
+    for layer in layers {
+        let path = tmp.dir_path().join(layer.digest.as_hex());
+        registry.apply_layer(&layer, &path).await?;
+    }
+
+    Ok(())
+}

--- a/lib/tests/it/docker.rs
+++ b/lib/tests/it/docker.rs
@@ -11,6 +11,11 @@ use simple_test_case::test_case;
 async fn pull_authed(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let auth = Authentication::docker(&reference).await?;
+    if matches!(auth, Authentication::None) {
+        eprintln!("skipping test; no docker auth found");
+        return Ok(());
+    }
+
     let registry = Registry::builder()
         .auth(auth)
         .reference(reference)

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1,3 +1,4 @@
+mod docker;
 mod platform;
 mod reference;
 mod registry;


### PR DESCRIPTION
# Overview

Pulls auth from docker config, using config helpers as appropriate.

## Acceptance criteria

Users that to analyze projects with authenticated registries are able to do so without manually specifying login credentials, assuming their auth is configured in Docker.

## Testing plan

Manually tested, but I need to add automated tests still.

## Metrics

None

## Risks

No risk

## References

Part of the prerequisite work for replacing current container pulling functionality in FOSSA CLI.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
