### PR TITLE
fix: Update release process to set version before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,22 @@ jobs:
         if: matrix.cross
         with:
           tool: cross
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-set-version
+
+      - name: set version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
+            # Remove the 'v' prefix for Cargo.toml versions
+            VERSION=${GITHUB_REF#refs/tags/v}
+            cargo set-version $VERSION
+          else
+            # For non-tag builds, use 0.0.0-{git-sha} format
+            GIT_SHA=$(git rev-parse --short HEAD)
+            cargo set-version "0.0.0-${GIT_SHA}"
+          fi
 
       - name: build
         shell: bash
@@ -140,19 +156,13 @@ jobs:
         with:
           tool: cargo-set-version
 
-      - name: version
+      - name: get version
         id: get_version
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
-            # Remove the 'v' prefix for Cargo.toml versions
-            VERSION=${GITHUB_REF#refs/tags/v}
-            echo "VERSION=v$VERSION" >> $GITHUB_OUTPUT
-            cargo set-version $VERSION
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            # For non-tag builds, use 0.0.0-{git-sha} format
-            GIT_SHA=$(git rev-parse --short HEAD)
             echo "VERSION=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            cargo set-version "0.0.0-${GIT_SHA}"
           fi
 
       - name: changelog


### PR DESCRIPTION
# Overview

This PR fixes the release process by setting the version before building rather than after. This ensures that the built artifacts contain the correct version information.

## Acceptance criteria

When a new release is created, the version number will be set in the Cargo.toml files before the build process runs, ensuring that the built binaries contain the correct version information.

## Testing plan

1. Verify the workflow file changes to confirm that the `set version` step happens before the build step
2. Ensure the `get version` step in the release job still correctly exports the version for the changelog
3. Test the workflow by creating a test tag and confirming the built artifacts contain the correct version

## Metrics

No specific metrics for this change, but it ensures release artifacts have the correct version information.

## Risks

Low risk change. The existing behavior of exporting the version for changelog generation is preserved, we're just moving the version setting step earlier in the process.

## References

N/A

## Checklist

- [x] Not applicable for workflow changes
