### PR TITLE
[1/N] Support FOSSA CLI: Part 1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tar filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -51,29 +51,19 @@ jobs:
       with:
         tool: cross
 
-    - uses: docker/login-action@v3
-      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
-      with:
-        registry: quay.io
-        username: fossa+sparkle
-        password: ${{ secrets.QUAY_API_KEY }}
-    - uses: docker/login-action@v3
-      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ github.token }}
-    - uses: docker/login-action@v3
-      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
-      with:
-        registry: docker.io
-        username: fossaeng
-        password: ${{ secrets.DOCKERHUB_API_KEY }}
-
     - name: tests
       run: |
         CARGO_COMMAND=${{ matrix.settings.cross && 'cross' || 'cargo' }}
+        HAS_DOCKER=${{ matrix.settings.host == 'ubuntu-latest' }}
         FEATURES=${{ matrix.settings.host == 'ubuntu-latest' && 'test-docker-interop' || 'default' }}
+
+        if [ "$HAS_DOCKER" = "true" ]; then
+          docker login -u fossaeng --password-stdin <<< ${{ secrets.DOCKERHUB_API_KEY }}
+          docker login quay.io -u fossa+sparkle --password-stdin <<< ${{ secrets.QUAY_API_KEY }}
+          docker login ghcr.io -u ${{ github.actor }} --password-stdin <<< ${{ github.token }}
+          cat ~/.docker/config.json
+        fi
+
         if [ "$CARGO_COMMAND" = "cross" ]; then
           $CARGO_COMMAND test --all-targets --features $FEATURES --target ${{ matrix.settings.target }}
         else

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -69,6 +69,12 @@ jobs:
         registry: docker.io
         username: fossaeng
         password: ${{ secrets.DOCKERHUB_API_KEY }}
+    - uses: docker/login-action@v3
+      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
+      with:
+        registry: https://index.docker.io/v1/
+        username: fossaeng
+        password: ${{ secrets.DOCKERHUB_API_KEY }}
 
     - name: tests
       run: |

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -63,6 +63,12 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ github.token }}
+    - uses: docker/login-action@v3
+      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
+      with:
+        registry: docker.io
+        username: fossaeng
+        password: ${{ secrets.DOCKERHUB_API_KEY }}
 
     - name: tests
       run: |

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -36,6 +36,9 @@ jobs:
     name: test / ${{ matrix.settings.host }} / ${{ matrix.settings.target }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        lfs: true
+        fetch-depth: 2
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
@@ -86,3 +89,30 @@ jobs:
       if: ${{ !matrix.settings.cross }}
       run: cargo test --doc --target ${{ matrix.settings.target }}
       shell: bash
+
+      # We can't run the integration tests on cross compiled hosts because they try to run circe itself with `cargo run`.
+      # For the purposes of the integration tests today, if they work on the standard host we're confident they'll work
+      # when cross compiled, but if this ever changes we can revisit this setup.
+    - name: integration tests (unix)
+      if: ${{ !matrix.settings.cross && matrix.settings.host != 'windows-latest' }}
+      run: |
+        HAS_DOCKER=${{ matrix.settings.host == 'ubuntu-latest' }}
+        FEATURES=${{ matrix.settings.host == 'ubuntu-latest' && 'test-docker-interop,test-integration' || 'test-integration' }}
+
+        if [ "$HAS_DOCKER" = "true" ]; then
+          docker login -u fossaeng --password-stdin <<< ${{ secrets.DOCKERHUB_API_KEY }}
+          docker login quay.io -u fossa+sparkle --password-stdin <<< ${{ secrets.QUAY_API_KEY }}
+          docker login ghcr.io -u ${{ github.actor }} --password-stdin <<< ${{ github.token }}
+        fi
+
+        curl https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+        cargo build
+        cargo nextest run -p circe_integration --features $FEATURES
+      shell: bash
+    - name: integration tests (windows)
+      if: ${{ !matrix.settings.cross && matrix.settings.host == 'windows-latest' }}
+      run: |
+        iwr -useb https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.ps1 | iex
+        cargo build
+        cargo nextest run -p circe_integration --features test-integration
+      shell: powershell

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -69,12 +69,6 @@ jobs:
         registry: docker.io
         username: fossaeng
         password: ${{ secrets.DOCKERHUB_API_KEY }}
-    - uses: docker/login-action@v3
-      if: ${{ matrix.settings.host == 'ubuntu-latest' }}
-      with:
-        registry: https://index.docker.io/v1/
-        username: fossaeng
-        password: ${{ secrets.DOCKERHUB_API_KEY }}
 
     - name: tests
       run: |

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -53,15 +53,14 @@ jobs:
 
     - name: tests
       run: |
+        HAS_DOCKER=${{ !matrix.settings.cross && matrix.settings.host == 'ubuntu-latest' }}
         CARGO_COMMAND=${{ matrix.settings.cross && 'cross' || 'cargo' }}
-        HAS_DOCKER=${{ matrix.settings.host == 'ubuntu-latest' }}
-        FEATURES=${{ matrix.settings.host == 'ubuntu-latest' && 'test-docker-interop' || 'default' }}
+        FEATURES=${{ (!matrix.settings.cross && matrix.settings.host == 'ubuntu-latest') && 'test-docker-interop' || 'default' }}
 
         if [ "$HAS_DOCKER" = "true" ]; then
           docker login -u fossaeng --password-stdin <<< ${{ secrets.DOCKERHUB_API_KEY }}
           docker login quay.io -u fossa+sparkle --password-stdin <<< ${{ secrets.QUAY_API_KEY }}
           docker login ghcr.io -u ${{ github.actor }} --password-stdin <<< ${{ github.token }}
-          cat ~/.docker/config.json
         fi
 
         if [ "$CARGO_COMMAND" = "cross" ]; then

--- a/.github/workflows/check-dynamic.yml
+++ b/.github/workflows/check-dynamic.yml
@@ -73,10 +73,11 @@ jobs:
     - name: tests
       run: |
         CARGO_COMMAND=${{ matrix.settings.cross && 'cross' || 'cargo' }}
+        FEATURES=${{ matrix.settings.host == 'ubuntu-latest' && 'test-docker-interop' || 'default' }}
         if [ "$CARGO_COMMAND" = "cross" ]; then
-          $CARGO_COMMAND test --all-targets --target ${{ matrix.settings.target }}
+          $CARGO_COMMAND test --all-targets --features $FEATURES --target ${{ matrix.settings.target }}
         else
-          cargo nextest run --all-targets --target ${{ matrix.settings.target }}
+          cargo nextest run --all-targets --features $FEATURES --target ${{ matrix.settings.target }}
         fi
       shell: bash
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bin", "lib"]
+members = ["bin", "integration", "lib"]
 resolver = "2"
 
 [profile.release]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -26,3 +26,6 @@ circe_lib = { path = "../lib" }
 serde_json = "1.0.133"
 derive_more = { version = "2.0.1", features = ["debug"] }
 pluralizer = "0.5.0"
+tokio-tar = "0.3.1"
+tap = "1.0.1"
+async-tempfile = "0.7.0"

--- a/bin/src/extract.rs
+++ b/bin/src/extract.rs
@@ -17,9 +17,8 @@ pub struct Options {
 
     /// Directory to which the extracted contents will be written
     ///
-    /// Layers are extracted into a subdirectory according to the `layers` option;
-    /// an `image.json` file is written to the output directory directly
-    /// describing the output.
+    /// Layers are extracted into subdirectories based on the `layers` option.
+    /// An `image.json` file is written to this directory with details about the extracted content.
     #[arg(default_value = ".")]
     output_dir: String,
 
@@ -133,7 +132,7 @@ pub struct Target {
 
 #[derive(Copy, Clone, Debug, Default, ValueEnum)]
 pub enum Mode {
-    /// Squash all layers into a single output directory.
+    /// Squash all layers into a single output directory, resulting in a file system equivalent to a running container.
     #[default]
     Squash,
 
@@ -146,7 +145,7 @@ pub enum Mode {
     /// Extract the base layer and all "other" layers; "other" layers are all layers except the base layer.
     BaseAndSquashOther,
 
-    /// Extract all layers to a separate directory for each layer.
+    /// Extract all layers to a separate directory for each layer, with each directory named after the layer's digest.
     Separate,
 }
 

--- a/bin/src/list.rs
+++ b/bin/src/list.rs
@@ -10,7 +10,7 @@ use crate::extract::Target;
 
 #[derive(Debug, Parser)]
 pub struct Options {
-    /// Target to list
+    /// Target container image to list layers and files from
     #[clap(flatten)]
     target: Target,
 }

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -1,0 +1,143 @@
+use async_tempfile::TempFile;
+use circe_lib::{
+    fossacli::{Image, Manifest, ManifestEntry, RootFs},
+    registry::Registry,
+    Authentication, Digest, Reference,
+};
+use clap::Parser;
+use color_eyre::eyre::{Context, Result};
+use derive_more::Debug;
+use pluralizer::pluralize;
+use std::str::FromStr;
+use tap::Pipe;
+use tokio_tar::Builder;
+use tracing::{info, warn};
+
+use crate::extract::Target;
+
+#[derive(Debug, Parser)]
+pub struct Options {
+    /// Target container image to re-export
+    #[clap(flatten)]
+    target: Target,
+
+    /// File path where the re-exported tarball will be written
+    #[arg(default_value = "image.tar")]
+    output: String,
+}
+
+#[tracing::instrument]
+pub async fn main(opts: Options) -> Result<()> {
+    info!("re-exporting image for FOSSA CLI");
+
+    let reference = Reference::from_str(&opts.target.image)?;
+    let auth = match (opts.target.username, opts.target.password) {
+        (Some(username), Some(password)) => Authentication::basic(username, password),
+        _ => Authentication::docker(&reference).await?,
+    };
+
+    let registry = Registry::builder()
+        .maybe_platform(opts.target.platform)
+        .reference(reference.clone())
+        .auth(auth)
+        .build()
+        .await
+        .context("configure remote registry")?;
+
+    let layers = registry.layers().await.context("list layers")?;
+    let count = layers.len();
+    info!("enumerated {}", pluralize("layer", count as isize, true));
+
+    // FOSSA CLI container scans start here:
+    // https://github.com/fossas/fossa-cli/blob/85a6977cb13ec2b8c5486dbbe464c61d6608bbd3/src/App/Fossa/Container/Scan.hs#L90
+    //
+    // It picks a strategy (Docker Archive, Docker Engine, Podman, or direct download from registry)
+    // and in all cases it first downloads a tarball representing the image and then parses it.
+    // For example, "direct download" is just "pull remote and export it to tarball" and then
+    // "open the tarball for parsing": https://github.com/fossas/fossa-cli/blob/85a6977cb13ec2b8c5486dbbe464c61d6608bbd3/src/App/Fossa/Container/Sources/Registry.hs#L84
+    //
+    // The main function that all these branches call is `analyzeFromDockerArchive`, which is here: https://github.com/fossas/fossa-cli/blob/3a003190692b66780d76210ee0fb35ac6375c8d2/src/App/Fossa/Container/Sources/DockerArchive.hs#L104
+    // This first parses the image into a `ContainerImageRaw` type: https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L61-L62
+    // This type is made up of two parts:
+    // - The `ManifestJson` (corresponds to `circe_lib::fossacli::Manifest`)
+    // - A collection of `ContainerLayer`s
+    //
+    // The `ManifestJson` type is parsed by walking the outermost layer of the tarball and attempting to parse every file entry,
+    // however the `millhone` CLI requires that it is named `manifest.json`:
+    // - https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L65-L74
+    // - https://github.com/fossas/fossa-cli/blob/e9e8adeaa94c8b225826c25f1e39868c7d38bf79/extlib/millhone/src/cmd/analyze_container.rs#L217-L220
+    //
+    // After parsing the manifest, FOSSA CLI immediately tries to parse the file at the path indicated by the `config` key:
+    // - https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L72
+    //
+    // It then builds a representation of the image based on the combination of these two files:
+    // - https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L74
+
+    let digest = registry.digest().await.context("get image digest")?;
+    let tag = format!("{}:{}", reference.name(), reference.version);
+
+    // It's a lot less error prone to use the disk as working state for the tarball we create:
+    // the `tokio-tar` library automatically creates a lot of metadata for us if it can use an on-disk artifact
+    // which we'd otherwise be stuck recreating.
+    //
+    // While this comes at the cost of a little more IO (we're indirecting through the disk)
+    // I think this is worth the cost unless it demonstrates to the contrary..
+    let tarball = TempFile::new().await.context("create tarball")?;
+    let mut tarball = Builder::new(tarball);
+    let mut written = Vec::new();
+
+    for (layer, sequence) in layers.into_iter().zip(1usize..) {
+        info!(layer = %layer, %sequence, "reading layer");
+
+        let Some(layer_tarball) = registry
+            .layer_plain_tarball(&layer)
+            .await
+            .context("fetch layer tarball")?
+        else {
+            warn!(layer = %layer, %sequence, "skipped layer");
+            continue;
+        };
+
+        tarball
+            .append_path_with_name(layer_tarball.file_path(), layer.digest.tarball_filename())
+            .await
+            .context("add layer to tarball")?;
+
+        info!(layer = %layer, %sequence, filename = %layer.digest.tarball_filename(), "added layer to tarball");
+        written.push(layer.digest.clone());
+    }
+
+    let (manifest, manifest_content) = ManifestEntry::builder()
+        .config(Image::filename(&digest))
+        .repo_tags(&tag)
+        .layers(written.iter().map(Digest::tarball_filename))
+        .build()
+        .pipe(Manifest::singleton)
+        .write_tempfile()
+        .await
+        .context("write manifest")?;
+    tarball
+        .append_path_with_name(manifest.file_path(), Manifest::filename())
+        .await
+        .context("add manifest to tarball")?;
+    info!(filename = %Manifest::filename().display(), manifest = %manifest_content, "added manifest to tarball");
+
+    let (image, image_content) = Image::from(RootFs::layers(written))
+        .write_tempfile()
+        .await
+        .context("write image")?;
+    tarball
+        .append_path_with_name(image.file_path(), Image::filename(&digest))
+        .await
+        .context("add image to tarball")?;
+    info!(filename = %Image::filename(&digest).display(), image = %image_content, "added image to tarball");
+
+    let tarball = tarball.into_inner().await.context("finish tarball")?;
+    tarball.sync_all().await.context("sync tarball")?;
+    tokio::fs::copy(tarball.file_path(), &opts.output)
+        .await
+        .context("copy tarball to destination")?;
+    info!(filename = %opts.output, "copied final tarball to destination");
+
+    Ok(())
+}

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "circe_integration"
+version = "0.0.0"
+edition = "2024"
+authors = ["Jessica Black <me@jessica.black>", "FOSSA Inc. <support@fossa.com>"]
+description = "Integration tests for circe"
+license = "MPL-2.0"
+repository = "https://github.com/fossas/circe"
+homepage = "https://github.com/fossas/circe"
+documentation = "https://docs.rs/circe"
+publish = false
+
+[features]
+default = []
+test-docker-interop = []
+test-integration = []
+
+[dependencies]
+# No runtime dependencies, this is just a test crate
+
+[dev-dependencies]
+assert_fs = "1.1.1"
+color-eyre = "0.6.3"
+pretty_assertions = "1.4.1"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
+simple_test_case = "1.1.0"
+test-log = { version = "0.2.15", features = ["trace"] }
+tokio = { version = "1.42.0", features = ["full"] }
+tracing = "0.1.41"
+xshell = "0.2.5"

--- a/integration/src/lib.rs
+++ b/integration/src/lib.rs
@@ -1,0 +1,9 @@
+//! Integration tests for Circe.
+//!
+//! This crate doesn't contain any actual functionality.
+//! It's just a container for integration tests that test the `circe` binary
+//! with external tools like the FOSSA CLI.
+
+// This function only exists to satisfy the compiler, as this crate doesn't have any real functionality
+#[doc(hidden)]
+pub fn _dummy() {}

--- a/integration/testdata/fossacli/Dockerfile.app_deps_example
+++ b/integration/testdata/fossacli/Dockerfile.app_deps_example
@@ -1,0 +1,35 @@
+# Testcase: app_deps_example.tar
+#
+# To Build:
+#   docker build -f Dockerfile.app.sample . -t app_deps_example:latest
+#
+# To Export:
+#   docker save app_deps_example:latest > app_deps_example.tar
+#
+# To Run:
+#   docker run -it app_deps_example:latest /bin/sh
+#
+# To Push:
+#   docker tag app_deps_example:latest fossaeng/app_deps_example:latest
+#   docker push fossaeng/app_deps_example:latest
+FROM alpine:3.14.6
+
+RUN apk add tree
+
+# Directory with setuptools targets
+#
+# /app # tree
+# .
+# └── services
+#     ├── a
+#     │   └── reqs.txt (pip+numpy)
+#     └── b
+#         ├── internal
+#         │   ├── reqs.txt (pip+scipy)
+#         │   └── test
+#         │       └── reqs.txt (pip+networkx)
+#         └── reqs.txt (pip+black)
+RUN mkdir -p app/services/a/ && echo 'numpy' > app/services/a/reqs.txt && \
+    mkdir -p app/services/b/ && echo 'scipy' > app/services/b/reqs.txt && \
+    mkdir -p app/services/b/internal/ && echo 'black' > app/services/b/internal/reqs.txt && \
+    mkdir -p app/services/b/internal/test/ && echo 'networkx' > app/services/b/internal/test/reqs.txt

--- a/integration/testdata/fossacli/Dockerfile.changeset_example
+++ b/integration/testdata/fossacli/Dockerfile.changeset_example
@@ -1,0 +1,48 @@
+# Testcase: changeset_exmaple.tar
+#
+# To Build:
+#   docker build -f Dockerfile.changeset_example . -t changeset_example:latest
+#
+# To Export:
+#   docker save changeset_example:latest > changeset_example.tar
+#
+# To Run:
+#   docker run -it changeset_example:latest /bin/sh
+#
+# To Push:
+#   docker tag changeset_example:latest fossaeng/changeset_example:latest
+#   docker push fossaeng/changeset_example:latest
+FROM alpine:3.14.6
+
+# Layer 1 - Adds a file and directory
+RUN echo '01-01-2022' > status.txt && \
+    echo 'OK' > health.txt \
+    && mkdir logs-archive
+
+# Layer 2 - Adds a nested file and a nested directory
+RUN echo '01-01-2022' > logs-archive/last.txt && \
+    cd logs-archive && mkdir jan && cd .. && \
+    cd logs-archive && mkdir feb && cd .. && \
+    cd logs-archive && mkdir march && cd .. && \
+    echo '1' > logs-archive/jan/1.txt && \
+    echo '2' > logs-archive/feb/2.txt
+
+# Layer 3 - Removes a file and directories
+RUN rm status.txt && \
+    rm logs-archive/jan/1.txt && \
+    rm -rf logs-archive/march
+
+# Layer 4 - Adds an absolute symbolic link and relative symbolic link
+RUN ln -s logs-archive/last.txt last && \
+    cd logs-archive/feb/ && \
+    ln -s ../../health.txt last_health
+
+# Layer 5 - Removes symbolic link
+RUN unlink last && \
+    unlink logs-archive/feb/last_health
+
+# Layer 6 - Removes a nested directory
+RUN rm -rf logs-archive
+
+# Layer 7 - Empty layer
+RUN echo "Bye!"

--- a/integration/testdata/fossacli/Dockerfile.changesets_symlinked_entries
+++ b/integration/testdata/fossacli/Dockerfile.changesets_symlinked_entries
@@ -1,0 +1,24 @@
+# Testcase: changesets_symlinked_entries.tar
+#
+# To Build:
+#   docker build -f Dockerfile.changesets_symlinked_entries . -t changesets_symlinked_entries:latest
+#
+# To Export:
+#   docker save changesets_symlinked_entries:latest > changesets_symlinked_entries.tar
+#
+# To Run:
+#   docker run -it changesets_symlinked_entries:latest /bin/sh
+#
+# To Push:
+#   docker tag changesets_symlinked_entries:latest fossaeng/changesets_symlinked_entries:latest
+#   docker push fossaeng/changesets_symlinked_entries:latest
+FROM busybox:1.34.1
+
+RUN echo 'a' > filea.txt
+WORKDIR /tmp
+
+RUN echo 'b' > fileb.txt
+WORKDIR /app
+
+RUN echo 'c' > filec.txt
+WORKDIR /tmp

--- a/integration/testdata/fossacli/app_deps_example.tar
+++ b/integration/testdata/fossacli/app_deps_example.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56eb7b304e19f447173f5db19dea84adeb30afe2f2c5935d5c71be58af301f29
+size 8182784

--- a/integration/testdata/fossacli/changeset_example.tar
+++ b/integration/testdata/fossacli/changeset_example.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c57602f76bc6efe1263df3bb044a603d6ad2f32ed0b0788b0f98196f1aa50ff
+size 5935104

--- a/integration/testdata/fossacli/changesets_symlinked_entries.tar
+++ b/integration/testdata/fossacli/changesets_symlinked_entries.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a55c19186d2e959a3e02633ca0b13f55ef6ed8351f8d393957c96027dd02f9b
+size 1501184

--- a/integration/tests/it/main.rs
+++ b/integration/tests/it/main.rs
@@ -1,0 +1,1 @@
+mod reexport;

--- a/integration/tests/it/reexport.rs
+++ b/integration/tests/it/reexport.rs
@@ -1,0 +1,147 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use assert_fs::prelude::*;
+use color_eyre::{Result, eyre::Context};
+use serde::Deserialize;
+use serde_json::Value;
+use simple_test_case::test_case;
+use xshell::{Shell, cmd};
+
+/// Test that `circe reexport` then allows FOSSA CLI to scan images
+/// that have previously been ticketed as failing to be analyzed.
+#[test_case(
+    "gcr.io/go-containerregistry/crane";
+    "gcr.io/go-containerregistry/crane"
+)]
+#[test_case(
+    "nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.9.0";
+    "nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.9.0"
+)]
+#[test_case(
+    "registry.access.redhat.com/ubi9/ubi-minimal@sha256:fb77e447ab97f3fecd15d2fa5361a99fe2f34b41422e8ebb3612eecd33922fa0";
+    "registry.access.redhat.com/ubi9/ubi-minimal@sha256:fb77e447ab97f3fecd15d2fa5361a99fe2f34b41422e8ebb3612eecd33922fa0"
+)]
+#[test_case(
+    "alpine:3.16.0";
+    "alpine:3.16.0"
+)]
+#[test_case(
+    "index.docker.io/library/alpine:latest";
+    "index.docker.io/library/alpine:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn scannable(image: &str) -> Result<()> {
+    let workspace = workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+
+    tracing::info!(image, target = %reexport, "run circe reexport");
+    cmd!(sh, "cargo run -- reexport {image} {reexport}").run()?;
+
+    tracing::info!(target = %reexport, "run fossa container analyze");
+    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
+
+    tracing::info!(target = %reexport, "read cli output");
+    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
+
+    // We don't have any images to compare, so we cannot do much in the way of assertions on the object.
+    // But at minimum, we can expect that the image should have contained layers.
+    assert!(
+        !reexport_output.image.layers.is_empty(),
+        "reexported image should have layers"
+    );
+
+    Ok(())
+}
+
+/// Test that the `circe reexport` command creates a tarball that when scanned with FOSSA CLI
+/// produces the same output as the original image (other than the `layerId`s).
+///
+/// Note: the actual vendored tarballs are copied from the tarballs with the same name
+/// in the FOSSA CLI repository; the Dockerfiles used to build the versions in Docker Hub
+/// are slightly different but conceptually the same.
+#[test_case(
+    "docker.io/fossaeng/changeset_example:latest",
+    "integration/testdata/fossacli/changeset_example.tar";
+    "fossaeng/changeset_example:latest"
+)]
+#[test_case(
+    "docker.io/fossaeng/changesets_symlinked_entries:latest",
+    "integration/testdata/fossacli/changesets_symlinked_entries.tar";
+    "fossaeng/changesets_symlinked_entries:latest"
+)]
+#[test_case(
+    "docker.io/fossaeng/app_deps_example:latest",
+    "integration/testdata/fossacli/app_deps_example.tar";
+    "fossaeng/app_deps_example:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(all(feature = "test-docker-interop", feature = "test-integration")),
+    ignore = "skipping integration tests that require docker to be installed"
+)]
+async fn compare(image: &str, reference: &str) -> Result<()> {
+    let workspace = workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+
+    tracing::info!(image, target = %reexport, "run circe reexport");
+    cmd!(sh, "cargo run -- reexport {image} {reexport}").run()?;
+
+    tracing::info!(target = %reexport, %reference, "run fossa container analyze");
+    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
+    let reference_output = cmd!(sh, "fossa container analyze {reference} -o").read()?;
+
+    tracing::info!(target = %reexport, %reference, "compare cli output");
+    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
+    let reference_output = serde_json::from_str::<CliContainerOutput>(&reference_output)?;
+
+    pretty_assertions::assert_eq!(reference_output, reexport_output);
+
+    Ok(())
+}
+
+/// The output of the `fossa container analyze` command.
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+struct CliContainerOutput {
+    image: CliContainerImage,
+}
+
+/// A container image reported by FOSSA CLI.
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CliContainerImage {
+    os: String,
+    os_release: String,
+    layers: Vec<CliContainerLayer>,
+}
+
+/// A layer reported by FOSSA CLI.
+///
+/// Contains a subset of the FOSSA CLI output fields that we want to compare for equality.
+/// The order of observations and source units don't matter to FOSSA and therefore they don't matter to circe.
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CliContainerLayer {
+    observations: HashSet<Value>,
+    src_units: HashSet<Value>,
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 [features]
 default = []
 test-custom-namespace = []
+test-docker-interop = []
 
 [dependencies]
 async-compression = { version = "0.4.18", features = ["tokio", "gzip", "zstd"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,10 +39,11 @@ serde_json = "1.0.138"
 static_assertions = "1.1.0"
 strum = { version = "0.27.0", features = ["derive"] }
 tap = "1.0.1"
-tokio = "1.42.0"
+tokio = { version = "1.42.0", features = ["process"] }
 tokio-tar = "0.3.1"
 tokio-util = { version = "0.7.13", features = ["io"] }
 tracing = "0.1.41"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 async-walkdir = "2.0.0"

--- a/lib/src/docker.rs
+++ b/lib/src/docker.rs
@@ -92,10 +92,10 @@ impl DockerConfig {
     async fn auth(&self, host: &str) -> Result<Authentication> {
         for key in Self::auth_keys(host) {
             if let Some(auth) = self.auths.get(key) {
-                match auth.decode(self, host).await {
+                match auth.decode(self, key).await {
                     Ok(auth) => return Ok(auth),
                     Err(err) => {
-                        warn!("failed decoding auth for host {key}: {err}");
+                        warn!("failed decoding auth for host {key:?}: {err:?}");
                         continue;
                     }
                 }
@@ -170,6 +170,7 @@ impl DockerAuth {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             return Err(eyre!("auth helper failed with status: {}", output.status))
                 .with_section(|| binary.clone().header("Helper binary:"))
+                .with_section(|| host.to_string().header("Host:"))
                 .with_section(|| output.status.to_string().header("Command status code:"))
                 .with_section(|| stderr.header("Stderr:"))
                 .with_section(|| stdout.header("Stdout:"));

--- a/lib/src/extract.rs
+++ b/lib/src/extract.rs
@@ -12,25 +12,25 @@ use sha2::{Digest as _, Sha256};
 use tap::Pipe;
 use tracing::info;
 
-/// Reports details about the image that was extracted.
+/// Report containing details about the extracted container image.
 #[derive(Debug, Serialize, Builder)]
 pub struct Report {
-    /// The orginal requested reference of the image that was extracted.
+    /// The original reference requested when extracting the image.
     #[builder(into)]
     pub reference: Reference,
 
-    /// The name of the image.
+    /// The repository name of the image.
     #[builder(into)]
     pub name: String,
 
-    /// The digest of the image.
+    /// The content-addressable digest of the image.
     #[builder(into)]
     pub digest: String,
 
-    /// The layers that were extracted, and the paths into which they were extracted.
+    /// The extracted layers and their corresponding filesystem paths.
     ///
-    /// If multiple layer digests point to the same directory,
-    /// this means they were squashed in the order indicated.
+    /// When multiple layer digests point to the same directory path,
+    /// it indicates those layers were squashed together in their application order.
     #[builder(into)]
     pub layers: Vec<(Digest, PathBuf)>,
 }
@@ -54,12 +54,15 @@ impl Report {
     }
 }
 
-/// The strategy used to extract one or more layers.
+/// Extraction strategy for container layers.
 pub enum Strategy {
-    /// The indicated layers are squashed into a single layer.
+    /// Squash multiple layers into a single unified filesystem.
+    ///
+    /// This applies layers in sequence, with each layer's changes
+    /// overlaying previous layers' contents.
     Squash(Vec<Layer>),
 
-    /// The layer is extracted as-is.
+    /// Extract a single layer to its own directory without combining it with others.
     Separate(Layer),
 }
 
@@ -72,7 +75,7 @@ impl IntoIterator for Strategy {
     }
 }
 
-/// Extract the layers.
+/// Extract container layers according to the specified strategies.
 pub async fn extract(
     registry: &Registry,
     output: &PathBuf,

--- a/lib/src/extract.rs
+++ b/lib/src/extract.rs
@@ -1,0 +1,148 @@
+use std::path::{Path, PathBuf};
+
+use crate::{registry::Registry, Digest, LayerDescriptor, Reference};
+use bon::Builder;
+use color_eyre::{
+    eyre::{Context, Error},
+    Result,
+};
+use futures_lite::{stream, StreamExt};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use tap::Pipe;
+use tracing::info;
+
+/// Reports details about the image that was extracted.
+#[derive(Debug, Serialize, Builder)]
+pub struct Report {
+    /// The orginal requested reference of the image that was extracted.
+    pub reference: Reference,
+
+    /// The name of the image.
+    pub name: String,
+
+    /// The digest of the image.
+    pub digest: String,
+
+    /// The layers that were extracted, and the paths into which they were extracted.
+    ///
+    /// If multiple layer digests point to the same directory,
+    /// this means they were squashed in the order indicated.
+    pub layers: Vec<(Digest, PathBuf)>,
+}
+
+impl Report {
+    /// The standard name for the report file.
+    // Note: if this changes, make sure to update the `extract` CLI documentation.
+    pub const FILENAME: &'static str = "image.json";
+
+    /// Write the report to its standard location in the output directory.
+    pub async fn write(&self, output: &Path) -> Result<()> {
+        let path = output.join(Self::FILENAME);
+        tokio::fs::write(&path, self.render()?)
+            .await
+            .context("write report")
+    }
+
+    /// Render the report to a string.
+    pub fn render(&self) -> Result<String> {
+        serde_json::to_string_pretty(self).context("serialize report")
+    }
+}
+
+/// The strategy used to extract one or more layers.
+pub enum Strategy {
+    /// The indicated layers are squashed into a single layer.
+    Squash(Vec<LayerDescriptor>),
+
+    /// The layer is extracted as-is.
+    Separate(LayerDescriptor),
+}
+
+/// Extract the layers.
+pub async fn extract(
+    registry: &Registry,
+    output: &PathBuf,
+    strategies: impl IntoIterator<Item = Strategy>,
+) -> Result<Report> {
+    let digest = registry.digest().await.context("fetch digest")?;
+
+    // TODO: we should be able to make these concurrent:
+    // each squash needs to happen in order but the strategies
+    // themselves are independent.
+    let layers = stream::iter(strategies)
+        .then(async |strategy| match strategy {
+            Strategy::Squash(layers) => squash(registry, output, &layers).await,
+            Strategy::Separate(layer) => copy(registry, output, layer).await,
+        })
+        .try_collect::<Vec<(Digest, PathBuf)>, Error, Vec<_>>()
+        .await
+        .context("apply layers")?
+        .pipe(|layers| layers.into_iter().flatten().collect::<Vec<_>>());
+
+    Report::builder()
+        .name(registry.original.name().to_string())
+        .reference(registry.original.clone())
+        .digest(digest.to_string())
+        .layers(layers)
+        .build()
+        .pipe(Ok)
+}
+
+async fn squash(
+    registry: &Registry,
+    output: &PathBuf,
+    layers: &[LayerDescriptor],
+) -> Result<Vec<(Digest, PathBuf)>> {
+    let target = target_dir(output, layers);
+    info!(layers = ?layers.iter().map(|l| &l.digest).collect::<Vec<_>>(), target = ?target.display(), "squash layers");
+
+    stream::iter(layers)
+        .then(async |layer| -> Result<(Digest, PathBuf)> {
+            tokio::fs::create_dir_all(&target).await?;
+            registry.apply_layer(layer, &target).await?;
+            Ok((layer.digest.clone(), target.clone()))
+        })
+        .try_collect()
+        .await
+}
+
+async fn copy(
+    registry: &Registry,
+    output: &PathBuf,
+    layer: LayerDescriptor,
+) -> Result<Vec<(Digest, PathBuf)>> {
+    let target = target_dir(output, [&layer]);
+    info!(layer = ?layer.digest, target = ?target.display(), "copy layer");
+
+    tokio::fs::create_dir_all(&target).await?;
+    registry.apply_layer(&layer, &target).await?;
+    Ok(vec![(layer.digest.clone(), target)])
+}
+
+/// Computes a directory for a set of layers to be squashed in the output directory.
+///
+/// If there is only one layer, the directory name is the digest of the layer.
+/// If there are multiple layers, the directory name is a hash of the digests of the layers.
+///
+/// Each variant has a short prefix; this is to handle the fact that it's technically possible
+/// to have layer digests clash. This really shouldn't ever happen, but better to be safe.
+fn target_dir<'a>(
+    output: &Path,
+    layers: impl IntoIterator<Item = &'a LayerDescriptor> + 'a,
+) -> PathBuf {
+    output.join(match layers.into_iter().collect::<Vec<_>>().as_slice() {
+        [] => unreachable!("empty layers"),
+        [layer] => format!("si_{}", layer.digest.as_hex()),
+        layers => layers
+            .iter()
+            .fold(Sha256::new(), |mut hasher, layer| {
+                hasher.update(&layer.digest.hash);
+                hasher
+            })
+            .finalize()
+            .to_vec()
+            .pipe_ref(hex::encode)
+            .pipe(|hash| format!("sq_{hash}")),
+    })
+}

--- a/lib/src/fossacli.rs
+++ b/lib/src/fossacli.rs
@@ -1,0 +1,163 @@
+//! Module for FOSSA CLI container compatibility support
+//!
+//! This module enables Circe to bridge between remote OCI container formats
+//! and the tarball format expected by FOSSA CLI's container scanning system.
+//!
+//! FOSSA CLI processes container images as tarballs during analysis.
+//! This module provides the necessary types and conversion utilities
+//! to transform container images into the specific tarball format
+//! that FOSSA CLI can parse and analyze.
+//!
+//! For reference implementations, see the test data in `/lib/tests/it/testdata/fossacli`
+//! which contains example tarballs that match FOSSA CLI's expected format.
+//! These examples are also available in the `fossaeng` DockerHub account,
+//! though the vendored examples in this repo are more reliable as reference
+//! implementations since they are not subject to Docker platform changes.
+
+use std::path::PathBuf;
+
+use async_tempfile::TempFile;
+use bon::Builder;
+use color_eyre::{eyre::Context, Result};
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+
+use crate::Digest;
+
+/// The manifest for a tarball image.
+///
+/// Corresponds to the FOSSA CLI `ManifestJson` type:
+/// https://github.com/fossas/fossa-cli/blob/0fc322a0e76e6fb6f78c0f3c13d6166d183ef830/src/Container/Docker/Manifest.hs#L45-L46
+///
+/// For Circe, this is a singleton list;
+/// FOSSA CLI just uses the first entry in the list:
+/// https://github.com/fossas/fossa-cli/blob/0fc322a0e76e6fb6f78c0f3c13d6166d183ef830/src/Container/Docker/Manifest.hs#L81-L82
+#[derive(Debug, Clone, Serialize)]
+pub struct Manifest(Vec<ManifestEntry>);
+
+impl Manifest {
+    /// Create a new manifest with a single entry.
+    pub fn singleton(entry: ManifestEntry) -> Self {
+        Self(vec![entry])
+    }
+
+    /// Build the target filename for the manifest.
+    pub fn filename() -> PathBuf {
+        PathBuf::from("manifest.json")
+    }
+
+    /// Write the manifest to a temporary file.
+    pub async fn write_tempfile(&self) -> Result<(TempFile, String)> {
+        write_serialized_tempfile(self).await
+    }
+}
+
+/// An image entry for the tarball manifest.
+///
+/// Corresponds to the FOSSA CLI `ManifestJsonImageEntry` type:
+/// https://github.com/fossas/fossa-cli/blob/0fc322a0e76e6fb6f78c0f3c13d6166d183ef830/src/Container/Docker/Manifest.hs#L54-L59
+#[derive(Debug, Clone, Serialize, Builder)]
+#[serde(rename_all = "PascalCase")]
+pub struct ManifestEntry {
+    /// References the path to the [`Image`] for this manifest.
+    ///
+    /// Must be named for the image digest; FOSSA CLI infers the image manifest from this filename:
+    /// https://github.com/fossas/fossa-cli/blob/0fc322a0e76e6fb6f78c0f3c13d6166d183ef830/src/Container/Docker/Manifest.hs#L84-L87
+    ///
+    /// FOSSA CLI parses the [`Image`] specified in this path immediately upon selecting a [`ManifestEntry`]
+    /// to represent the image: https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L70-L74
+    #[builder(into)]
+    config: PathBuf,
+
+    /// References pointing to this image.
+    ///
+    /// Despite the naming, this supports both tags and digests:
+    /// - redis:alpine
+    /// - redis@sha256:1234567890
+    ///
+    /// For the purposes of Circe, this is a singleton list;
+    /// FOSSA CLI just uses the first tag in the list to represent the tag
+    /// for the overall image:
+    /// - https://github.com/fossas/fossa-cli/blob/0fc322a0e76e6fb6f78c0f3c13d6166d183ef830/src/Container/Docker/Manifest.hs#L89-L92
+    /// - https://github.com/fossas/fossa-cli/blob/3a003190692b66780d76210ee0fb35ac6375c8d2/src/App/Fossa/Container/Sources/DockerArchive.hs#L292-L305
+    /// - https://github.com/fossas/fossa-cli/blob/3a003190692b66780d76210ee0fb35ac6375c8d2/src/App/Fossa/Container/Sources/DockerArchive.hs#L118
+    #[builder(with = |tag: impl Into<String>| vec![tag.into()])]
+    repo_tags: Vec<String>,
+
+    /// Points to the filesystem changeset tars.
+    ///
+    /// The layers need to be in the same order as the `diff_ids` specified in the [`RootFs`]
+    /// for the [`Image`] indicated by [`ManifestEntry::config`] as they are just zipped together:
+    /// - https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L74
+    /// - https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L140
+    #[builder(with = |layers: impl IntoIterator<Item = impl Into<PathBuf>>| layers.into_iter().map(Into::into).collect())]
+    layers: Vec<PathBuf>,
+}
+
+/// Container image configuration for FOSSA CLI.
+#[derive(Debug, Clone, Serialize)]
+pub struct Image {
+    /// The root filesystem definition containing the container's layer information.
+    pub rootfs: RootFs,
+}
+
+impl Image {
+    /// Build the target filename for the image.
+    pub fn filename(digest: &Digest) -> PathBuf {
+        let digest = digest.as_hex();
+        PathBuf::from(format!("{digest}.json"))
+    }
+
+    /// Write the image to a temporary file.
+    pub async fn write_tempfile(&self) -> Result<(TempFile, String)> {
+        write_serialized_tempfile(self).await
+    }
+}
+
+impl From<RootFs> for Image {
+    fn from(rootfs: RootFs) -> Self {
+        Self { rootfs }
+    }
+}
+
+impl From<&RootFs> for Image {
+    fn from(rootfs: &RootFs) -> Self {
+        rootfs.clone().into()
+    }
+}
+
+/// Root filesystem structure for a container image.
+///
+/// This defines how container layers are organized in the filesystem.
+/// FOSSA CLI uses this structure to understand which layers make up
+/// the container and in what order they should be applied.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum RootFs {
+    /// A layered filesystem structure composed of multiple layer diff IDs.
+    ///
+    /// This is the only rootfs type supported by FOSSA CLI's container analyzer.
+    /// The layers must be listed in application order (base layer first).
+    Layers {
+        /// The content-addressable digests of each layer in application order.
+        diff_ids: Vec<String>,
+    },
+}
+
+impl RootFs {
+    /// Create a new `Layers` variant from the provided diff ids.
+    pub fn layers(diff_ids: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self::Layers {
+            diff_ids: diff_ids.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// Serializes a value to JSON and writes it to a temporary file.
+async fn write_serialized_tempfile<T: Serialize>(value: &T) -> Result<(TempFile, String)> {
+    let mut file = TempFile::new().await.context("create")?;
+    let value = serde_json::to_string_pretty(&value).context("serialize")?;
+    file.write_all(value.as_bytes()).await.context("write")?;
+    file.sync_all().await.context("sync")?;
+    Ok((file, value))
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -18,6 +18,7 @@ use tracing::{debug, warn};
 mod docker;
 mod ext;
 pub mod extract;
+pub mod fossacli;
 pub mod registry;
 pub mod transform;
 
@@ -321,6 +322,11 @@ impl Digest {
     pub fn as_hex(&self) -> String {
         hex::encode(&self.hash)
     }
+
+    /// Returns the filename to use for a tarball with this digest.
+    pub fn tarball_filename(&self) -> String {
+        format!("{}.tar", self.as_hex())
+    }
 }
 
 impl FromStr for Digest {
@@ -587,6 +593,18 @@ pub struct Layer {
 
     /// The media type of the layer
     pub media_type: LayerMediaType,
+}
+
+impl Layer {
+    /// Convenience reference to the digest for the layer.
+    pub fn digest(&self) -> &Digest {
+        &self.digest
+    }
+
+    /// Convenience reference to the digest for the layer as a hex string.
+    pub fn digest_hex(&self) -> String {
+        self.digest.as_hex()
+    }
 }
 
 impl From<&Layer> for Layer {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,6 +7,7 @@ use color_eyre::{
 };
 use derive_more::derive::{Debug, Display, From};
 use enum_assoc::Assoc;
+use extract::Strategy;
 use itertools::Itertools;
 use serde::{Serialize, Serializer};
 use std::{borrow::Cow, ops::Add, path::PathBuf, str::FromStr};
@@ -364,6 +365,18 @@ impl Serialize for Digest {
     }
 }
 
+impl From<Digest> for String {
+    fn from(digest: Digest) -> Self {
+        digest.to_string()
+    }
+}
+
+impl From<&Digest> for String {
+    fn from(digest: &Digest) -> Self {
+        digest.to_string()
+    }
+}
+
 /// Version identifier for a container image.
 ///
 /// This can be a named tag or a SHA256 digest.
@@ -564,7 +577,7 @@ impl std::fmt::Display for Reference {
 /// A descriptor for a specific layer within an OCI container image.
 /// This follows the OCI Image Spec's layer descriptor format.
 #[derive(Debug, Clone, PartialEq, Eq, Builder)]
-pub struct LayerDescriptor {
+pub struct Layer {
     /// The content-addressable digest of the layer
     #[builder(into)]
     pub digest: Digest,
@@ -576,15 +589,27 @@ pub struct LayerDescriptor {
     pub media_type: LayerMediaType,
 }
 
-impl From<&LayerDescriptor> for LayerDescriptor {
-    fn from(layer: &LayerDescriptor) -> Self {
+impl From<&Layer> for Layer {
+    fn from(layer: &Layer) -> Self {
         layer.clone()
     }
 }
 
-impl std::fmt::Display for LayerDescriptor {
+impl std::fmt::Display for Layer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.digest)
+    }
+}
+
+impl From<Layer> for Strategy {
+    fn from(layer: Layer) -> Self {
+        Strategy::Separate(layer)
+    }
+}
+
+impl From<&Layer> for Strategy {
+    fn from(layer: &Layer) -> Self {
+        Strategy::Separate(layer.clone())
     }
 }
 

--- a/lib/tests/it/docker.rs
+++ b/lib/tests/it/docker.rs
@@ -9,13 +9,13 @@ use simple_test_case::test_case;
 #[test_case("ghcr.io/fossas/sherlock/server:latest"; "ghcr.io/fossas/sherlock/server:latest")]
 #[test_case("docker.io/fossaeng/hellotest:latest"; "docker.io/fossaeng/hellotest:latest")]
 #[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-docker-interop"),
+    ignore = "ignoring tests that require docker to be installed"
+)]
 async fn pull_authed(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let auth = Authentication::docker(&reference).await?;
-    if matches!(auth, Authentication::None) {
-        eprintln!("skipping test; no docker auth found");
-        return Ok(());
-    }
 
     let registry = Registry::builder()
         .auth(auth)

--- a/lib/tests/it/docker.rs
+++ b/lib/tests/it/docker.rs
@@ -7,6 +7,7 @@ use simple_test_case::test_case;
 // This is performed before tests are run in CI, but you may need to `docker login` locally.
 #[test_case("quay.io/fossa/hubble-api:latest"; "quay.io/fossa/hubble-api:latest")]
 #[test_case("ghcr.io/fossas/sherlock/server:latest"; "ghcr.io/fossas/sherlock/server:latest")]
+#[test_case("docker.io/fossaeng/hellotest:latest"; "docker.io/fossaeng/hellotest:latest")]
 #[test_log::test(tokio::test)]
 async fn pull_authed(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -106,7 +106,7 @@ async fn report(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
 #[test_log::test(tokio::test)]
 async fn squash(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -149,7 +149,7 @@ async fn base(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
 #[test_log::test(tokio::test)]
 async fn squash_other(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -173,7 +173,7 @@ async fn squash_other(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
 #[test_log::test(tokio::test)]
 async fn base_and_squash_other(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -201,7 +201,7 @@ async fn base_and_squash_other(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
 #[test_log::test(tokio::test)]
 async fn separate(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -1,0 +1,228 @@
+use async_tempfile::TempDir;
+use circe_lib::{
+    extract::{extract, Report, Strategy},
+    registry::Registry,
+    Digest, Reference,
+};
+use color_eyre::Result;
+use serde_json::{json, Value};
+use simple_test_case::test_case;
+use std::{path::PathBuf, str::FromStr};
+
+macro_rules! assert_layers_extracted {
+    ($report:expr, $layers:expr) => {
+        pretty_assertions::assert_eq!(
+            $report
+                .layers
+                .iter()
+                .map(|(l, _)| l.to_string())
+                .collect::<Vec<_>>(),
+            $layers.into_iter().collect::<Vec<_>>(),
+            "expected layers not found in report",
+        );
+    };
+}
+
+#[test_log::test(tokio::test)]
+async fn report_roundtrip() -> Result<()> {
+    let reference = Reference::from_str("cgr.dev/chainguard/wolfi-base:latest")?;
+    let digest_img = Digest::from_str(
+        "sha256:931040ffeedc9148b2ed852bc1a9531af141a6bc1f4761ea96c1f2c13b8b6659",
+    )?;
+    let digest_layer_1 = Digest::from_str(
+        "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+    )?;
+    let digest_layer_2 = Digest::from_str(
+        "sha256:b3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+    )?;
+
+    let report = Report::builder()
+        .name("wolfi-base")
+        .reference(reference)
+        .digest(digest_img.clone())
+        .layers([
+            (digest_layer_1.clone(), PathBuf::from("/tmp/layer1")),
+            (digest_layer_2.clone(), PathBuf::from("/tmp/layer2")),
+        ])
+        .build();
+
+    let json = report.render()?;
+    let parsed = serde_json::from_str::<Value>(&json)?;
+
+    pretty_assertions::assert_eq!(
+        parsed,
+        json!({
+            "name": "wolfi-base",
+            "digest": digest_img.to_string(),
+            "reference": {
+                "host": "cgr.dev",
+                "repository": "chainguard/wolfi-base",
+                "version": {
+                    "kind": "tag",
+                    "value": "latest"
+                }
+            },
+            "layers": [
+                [digest_layer_1.to_string(), "/tmp/layer1"],
+                [digest_layer_2.to_string(), "/tmp/layer2"],
+            ],
+        })
+    );
+
+    Ok(())
+}
+
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_log::test(tokio::test)]
+async fn report(image: &str) -> Result<()> {
+    let reference = image.parse::<Reference>()?;
+    let registry = Registry::builder().reference(reference).build().await?;
+
+    let tmp = TempDir::new().await?;
+    let layers = registry.layers().await?;
+    assert!(!layers.is_empty(), "image should have at least one layer");
+
+    let report = extract(
+        &registry,
+        tmp.dir_path(),
+        layers.iter().cloned().map(Strategy::Separate),
+    )
+    .await?;
+
+    pretty_assertions::assert_eq!(report.name, registry.original.name());
+    pretty_assertions::assert_eq!(report.reference, registry.original);
+
+    let actual_digest = registry.digest().await?;
+    pretty_assertions::assert_eq!(report.digest, actual_digest.to_string());
+    assert_layers_extracted!(report, layers.iter().map(|l| l.digest.to_string()));
+
+    // Hard coded so that tests will notice if we accidentally change this path
+    let path = tmp.dir_path().join("image.json");
+    report.write(&tmp.dir_path()).await?;
+
+    let report_text = tokio::fs::read_to_string(&path).await?;
+    pretty_assertions::assert_eq!(report_text, report.render()?);
+
+    Ok(())
+}
+
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_log::test(tokio::test)]
+async fn squash(image: &str) -> Result<()> {
+    let reference = image.parse::<Reference>()?;
+    let registry = Registry::builder().reference(reference).build().await?;
+
+    let tmp = TempDir::new().await?;
+    let layers = registry.layers().await?;
+    assert!(!layers.is_empty(), "image should have at least one layer");
+
+    let report = extract(&registry, tmp.dir_path(), Strategy::Squash(layers)).await?;
+
+    // We don't really know what the contents of the images will be over time,
+    // so we just check that the layers are as we expect for this test.
+    // The rest of the report is tested more thoroughly in `report`.
+    assert!(!report.layers.is_empty(), "layers must have been extracted");
+
+    Ok(())
+}
+
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_log::test(tokio::test)]
+async fn base(image: &str) -> Result<()> {
+    let reference = image.parse::<Reference>()?;
+    let registry = Registry::builder().reference(reference).build().await?;
+
+    let tmp = TempDir::new().await?;
+    let base = registry
+        .layers()
+        .await?
+        .first()
+        .cloned()
+        .expect("image should have at least one layer");
+    let report = extract(&registry, tmp.dir_path(), Strategy::Separate(base.clone())).await?;
+
+    // We don't really know what the contents of the images will be over time,
+    // so we just check that the layers are as we expect for this test.
+    // The rest of the report is tested more thoroughly in `report`.
+    assert_layers_extracted!(report, [base.digest.to_string()]);
+
+    Ok(())
+}
+
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_log::test(tokio::test)]
+async fn squash_other(image: &str) -> Result<()> {
+    let reference = image.parse::<Reference>()?;
+    let registry = Registry::builder().reference(reference).build().await?;
+
+    let tmp = TempDir::new().await?;
+    let layers = registry.layers().await?;
+
+    let report = extract(
+        &registry,
+        tmp.dir_path(),
+        Strategy::Squash(layers.into_iter().skip(1).collect()),
+    )
+    .await?;
+
+    // We don't really know what the contents of the images will be over time,
+    // so we just check that the layers are as we expect for this test.
+    // The rest of the report is tested more thoroughly in `report`.
+    assert!(!report.layers.is_empty(), "layers must have been extracted");
+
+    Ok(())
+}
+
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_log::test(tokio::test)]
+async fn base_and_squash_other(image: &str) -> Result<()> {
+    let reference = image.parse::<Reference>()?;
+    let registry = Registry::builder().reference(reference).build().await?;
+
+    let tmp = TempDir::new().await?;
+    let layers = registry.layers().await?;
+
+    let strategies = match layers.as_slice() {
+        [] => unreachable!(),
+        [base] => vec![Strategy::Separate(base.clone())],
+        [base, rest @ ..] => vec![
+            Strategy::Separate(base.clone()),
+            Strategy::Squash(rest.to_vec()),
+        ],
+    };
+
+    let report = extract(&registry, tmp.dir_path(), strategies).await?;
+
+    // We don't really know what the contents of the images will be over time,
+    // so we just check that the layers are as we expect for this test.
+    // The rest of the report is tested more thoroughly in `report`.
+    assert!(!report.layers.is_empty(), "layers must have been extracted");
+
+    Ok(())
+}
+
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_log::test(tokio::test)]
+async fn separate(image: &str) -> Result<()> {
+    let reference = image.parse::<Reference>()?;
+    let registry = Registry::builder().reference(reference).build().await?;
+
+    let layers = registry.layers().await?;
+    assert!(!layers.is_empty(), "image should have at least one layer");
+
+    let tmp = TempDir::new().await?;
+    let strategies = layers
+        .iter()
+        .cloned()
+        .map(Strategy::Separate)
+        .collect::<Vec<_>>();
+
+    let report = extract(&registry, tmp.dir_path(), strategies).await?;
+
+    // We don't really know what the contents of the images will be over time,
+    // so we just check that the layers are as we expect for this test.
+    // The rest of the report is tested more thoroughly in `report`.
+    assert_layers_extracted!(report, layers.iter().map(|l| l.digest.to_string()));
+
+    Ok(())
+}

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -73,6 +73,7 @@ async fn report_roundtrip() -> Result<()> {
 }
 
 #[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
 async fn report(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -106,7 +107,8 @@ async fn report(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
 async fn squash(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -127,6 +129,7 @@ async fn squash(image: &str) -> Result<()> {
 }
 
 #[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
 async fn base(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -149,7 +152,8 @@ async fn base(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
+/// Requires an image with more than one layer
+#[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
 async fn squash_other(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -173,7 +177,8 @@ async fn squash_other(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
+/// Requires an image with more than one layer
+#[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
 async fn base_and_squash_other(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -201,7 +206,8 @@ async fn base_and_squash_other(image: &str) -> Result<()> {
     Ok(())
 }
 
-#[test_case("docker.io/library/ubuntu:latest"; "docker.io/library/ubuntu:latest")]
+#[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
+#[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
 async fn separate(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -75,6 +75,10 @@ async fn report_roundtrip() -> Result<()> {
 #[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
 #[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-docker-interop"),
+    ignore = "ignoring tests that require docker to be installed"
+)]
 async fn report(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let registry = Registry::builder().reference(reference).build().await?;
@@ -110,6 +114,10 @@ async fn report(image: &str) -> Result<()> {
 #[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
 #[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-docker-interop"),
+    ignore = "ignoring tests that require docker to be installed"
+)]
 async fn squash(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let registry = Registry::builder().reference(reference).build().await?;
@@ -131,6 +139,10 @@ async fn squash(image: &str) -> Result<()> {
 #[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
 #[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-docker-interop"),
+    ignore = "ignoring tests that require docker to be installed"
+)]
 async fn base(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let registry = Registry::builder().reference(reference).build().await?;
@@ -155,6 +167,10 @@ async fn base(image: &str) -> Result<()> {
 /// Requires an image with more than one layer
 #[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-docker-interop"),
+    ignore = "ignoring tests that require docker to be installed"
+)]
 async fn squash_other(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let registry = Registry::builder().reference(reference).build().await?;
@@ -180,6 +196,10 @@ async fn squash_other(image: &str) -> Result<()> {
 /// Requires an image with more than one layer
 #[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-docker-interop"),
+    ignore = "ignoring tests that require docker to be installed"
+)]
 async fn base_and_squash_other(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let registry = Registry::builder().reference(reference).build().await?;
@@ -209,6 +229,10 @@ async fn base_and_squash_other(image: &str) -> Result<()> {
 #[test_case("cgr.dev/chainguard/wolfi-base:latest"; "cgr.dev/chainguard/wolfi-base:latest")]
 #[test_case("docker.io/contribsys/faktory:latest"; "docker.io/contribsys/faktory:latest")]
 #[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-docker-interop"),
+    ignore = "ignoring tests that require docker to be installed"
+)]
 async fn separate(image: &str) -> Result<()> {
     let reference = image.parse::<Reference>()?;
     let registry = Registry::builder().reference(reference).build().await?;

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1,4 +1,5 @@
 mod docker;
+mod extract;
 mod platform;
 mod reference;
 mod registry;

--- a/lib/tests/it/registry.rs
+++ b/lib/tests/it/registry.rs
@@ -8,7 +8,6 @@ use simple_test_case::test_case;
 #[test_case("cgr.dev/chainguard/wolfi-base:latest", Some(Platform::linux_arm64()); "cgr.dev/chainguard/wolfi-base:latest.linux_arm64")]
 #[test_case("cgr.dev/chainguard/wolfi-base:latest", None; "cgr.dev/chainguard/wolfi-base:latest_default")]
 #[test_case("docker.io/library/ubuntu:latest", None; "docker.io/library/ubuntu:latest_default")]
-#[test_case("docker.io/library/alpine:latest", None; "docker.io/library/alpine:latest_default")]
 #[test_log::test(tokio::test)]
 async fn pull_layer(image: &str, platform: Option<Platform>) -> Result<()> {
     let reference = image.parse::<Reference>()?;
@@ -101,7 +100,6 @@ async fn pull_layer_filtered(
 #[test_case("cgr.dev/chainguard/wolfi-base:latest", Some(Platform::linux_arm64()); "cgr.dev/chainguard/wolfi-base:latest.linux_arm64")]
 #[test_case("cgr.dev/chainguard/wolfi-base:latest", None; "cgr.dev/chainguard/wolfi-base:latest_default")]
 #[test_case("docker.io/library/ubuntu:latest", None; "docker.io/library/ubuntu:latest_default")]
-#[test_case("docker.io/library/alpine:latest", None; "docker.io/library/alpine:latest_default")]
 #[test_log::test(tokio::test)]
 async fn list_layer(image: &str, platform: Option<Platform>) -> Result<()> {
     let reference = image.parse::<Reference>()?;


### PR DESCRIPTION
# Overview

A few changes required to support using Circe in FOSSA CLI.
- A JSON file describing the state of the container extraction and metadata FOSSA CLI needs.
- Support for "extract base and squash other layers" mode.
- Fixes a logic bug in using DockerHub authentication.

## Acceptance criteria

- Able to extract base and squashed other layers.
- The JSON file works for the needs of FOSSA CLI.
- Able to use DockerHub auth.

## Testing plan

Mainly automated testing, but I also manually validated with some containers.

## Risks

No major risk

## References

Part of the work in FOSSA CLI to use circe for extracting containers.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
