### PR TITLE
Additional Sources: Docker daemon, `docker save`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,19 @@ cargo nextest run --package circe_lib path::to::module
 ## Code Style Guidelines
 - **Formatting**: Use rustfmt, consistent with surrounding code
 - **Naming**: snake_case for functions/variables, CamelCase for types
+- **Variable Shadowing**: Prefer shadowing variables rather than using Hungarian notation (e.g., use `let path = path.to_string_lossy()` instead of `let path_str = path.to_string_lossy()`)
 - **Imports**: Group std lib, external crates, internal modules (alphabetically)
 - **Error Handling**: Use color-eyre with context(), ensure!(), bail!()
 - **Types**: Prefer Builder pattern, derive common traits, use strong types
-- **Documentation**: Comments explain "why" not "what", use proper sentences
+- **Documentation**: Comments explain "why" not "what", use proper sentences. Avoid redundant comments that merely describe what code does - good code should be self-explanatory
 - **Organization**: Modular approach, named module files (not mod.rs)
 - **Testing**: Add integration tests in tests/it/, use test_case macro
 - **Functional Style**: Avoid mutation, prefer functional patterns when possible
 - **Cargo**: Never edit Cargo.toml directly, use cargo edit commands
 - **Conversions**: Use Type::from(value) not let x: Type = value.into()
+- **String Formatting**: 
+  - For simple variables, use direct interpolation: `"Value: {variable}"` instead of `"Value: {}", variable`
+  - For expressions (method calls, etc.), use traditional formatting: `"Value: {}", expression.method()`
+  - This project enforces `clippy::uninlined_format_args` for simple variables
 
 Set `RUST_LOG=debug` or `RUST_LOG=trace` for detailed logs during development.

--- a/bin/src/extract.rs
+++ b/bin/src/extract.rs
@@ -155,7 +155,7 @@ pub enum Mode {
 #[tracing::instrument]
 pub async fn main(opts: Options) -> Result<()> {
     info!("extracting image");
-    try_strategies!(&opts; strategy_registry, strategy_daemon, strategy_tarball)
+    try_strategies!(&opts; strategy_tarball, strategy_daemon, strategy_registry)
 }
 
 async fn strategy_registry(opts: &Options) -> Result<()> {
@@ -179,7 +179,9 @@ async fn strategy_registry(opts: &Options) -> Result<()> {
         .await
         .context("configure remote registry")?;
 
-    extract_layers(opts, registry).await.context("list files")
+    extract_layers(opts, registry)
+        .await
+        .context("extract layers")
 }
 
 async fn strategy_daemon(opts: &Options) -> Result<()> {
@@ -197,7 +199,7 @@ async fn strategy_daemon(opts: &Options) -> Result<()> {
         .context("build daemon reference")?;
 
     tracing::info!("pulled image from daemon");
-    extract_layers(opts, daemon).await.context("list files")
+    extract_layers(opts, daemon).await.context("extract layers")
 }
 
 async fn strategy_tarball(opts: &Options) -> Result<()> {
@@ -225,8 +227,10 @@ async fn strategy_tarball(opts: &Options) -> Result<()> {
         .await
         .context("build tarball reference")?;
 
-    tracing::info!("pulled image from daemon");
-    extract_layers(opts, tarball).await.context("list files")
+    tracing::info!("extracting layers from tarball");
+    extract_layers(opts, tarball)
+        .await
+        .context("extract layers")
 }
 
 #[tracing::instrument]

--- a/bin/src/extract.rs
+++ b/bin/src/extract.rs
@@ -1,7 +1,7 @@
 use circe_lib::{
     extract::{extract, Report, Strategy},
     registry::Registry,
-    Authentication, Filters, Platform, Reference,
+    Authentication, Filters, Platform, Reference, Source,
 };
 use clap::{Args, Parser, ValueEnum};
 use color_eyre::eyre::{bail, Context, Result};

--- a/bin/src/extract.rs
+++ b/bin/src/extract.rs
@@ -133,6 +133,13 @@ pub struct Target {
     pub password: Option<String>,
 }
 
+impl Target {
+    /// Check if the image appears to be a path
+    pub fn is_path(&self) -> bool {
+        self.image.starts_with('/') || self.image.starts_with("./") || self.image.starts_with("../")
+    }
+}
+
 #[derive(Copy, Clone, Debug, Default, ValueEnum)]
 pub enum Mode {
     /// Squash all layers into a single output directory, resulting in a file system equivalent to a running container.
@@ -159,6 +166,11 @@ pub async fn main(opts: Options) -> Result<()> {
 }
 
 async fn strategy_registry(opts: &Options) -> Result<()> {
+    if opts.target.is_path() {
+        debug!("input appears to be a file path, skipping strategy");
+        return Ok(());
+    }
+
     let reference = Reference::from_str(&opts.target.image)?;
     let layer_globs = Filters::parse_glob(opts.layer_glob.iter().flatten())?;
     let file_globs = Filters::parse_glob(opts.file_glob.iter().flatten())?;
@@ -185,6 +197,11 @@ async fn strategy_registry(opts: &Options) -> Result<()> {
 }
 
 async fn strategy_daemon(opts: &Options) -> Result<()> {
+    if opts.target.is_path() {
+        debug!("input appears to be a file path, skipping strategy");
+        return Ok(());
+    }
+
     let layer_globs = Filters::parse_glob(opts.layer_glob.iter().flatten())?;
     let file_globs = Filters::parse_glob(opts.file_glob.iter().flatten())?;
     let layer_regexes = Filters::parse_regex(opts.layer_regex.iter().flatten())?;

--- a/bin/src/extract.rs
+++ b/bin/src/extract.rs
@@ -1,5 +1,5 @@
 use circe_lib::{
-    extract::{extract, Strategy},
+    extract::{extract, Report, Strategy},
     registry::Registry,
     Authentication, Filters, Platform, Reference,
 };
@@ -194,9 +194,17 @@ pub async fn main(opts: Options) -> Result<()> {
         },
     };
 
-    let report = extract(&registry, &output, strategies)
+    let digest = registry.digest().await.context("fetch digest")?;
+    let layers = extract(&registry, &output, strategies)
         .await
         .context("extract image")?;
+
+    let report = Report::builder()
+        .name(registry.original.name.clone())
+        .reference(registry.original.clone())
+        .digest(digest.to_string())
+        .layers(layers)
+        .build();
 
     report
         .write(&output)

--- a/bin/src/list.rs
+++ b/bin/src/list.rs
@@ -26,7 +26,7 @@ pub async fn main(opts: Options) -> Result<()> {
 }
 
 async fn strategy_registry(opts: &Options) -> Result<Outcome> {
-    if opts.target.is_path() {
+    if opts.target.is_path().await {
         debug!("input appears to be a file path, skipping strategy");
         return Ok(Outcome::Skipped);
     }
@@ -52,7 +52,7 @@ async fn strategy_registry(opts: &Options) -> Result<Outcome> {
 }
 
 async fn strategy_daemon(opts: &Options) -> Result<Outcome> {
-    if opts.target.is_path() {
+    if opts.target.is_path().await {
         debug!("input appears to be a file path, skipping strategy");
         return Ok(Outcome::Skipped);
     }

--- a/bin/src/list.rs
+++ b/bin/src/list.rs
@@ -22,7 +22,7 @@ pub struct Options {
 #[tracing::instrument]
 pub async fn main(opts: Options) -> Result<()> {
     info!("extracting image");
-    try_strategies!(&opts; strategy_tarball,strategy_registry, strategy_daemon);
+    try_strategies!(&opts; strategy_tarball, strategy_daemon, strategy_registry)
 }
 
 async fn strategy_registry(opts: &Options) -> Result<()> {
@@ -72,7 +72,7 @@ async fn strategy_tarball(opts: &Options) -> Result<()> {
         .await
         .context("build tarball reference")?;
 
-    tracing::info!("pulled image from daemon");
+    tracing::info!("listing files in tarball");
     list_files(tarball).await.context("list files")
 }
 

--- a/bin/src/list.rs
+++ b/bin/src/list.rs
@@ -26,6 +26,11 @@ pub async fn main(opts: Options) -> Result<()> {
 }
 
 async fn strategy_registry(opts: &Options) -> Result<()> {
+    if opts.target.is_path() {
+        debug!("input appears to be a file path, skipping strategy");
+        return Ok(());
+    }
+
     let reference = Reference::from_str(&opts.target.image)?;
     let auth = match (&opts.target.username, &opts.target.password) {
         (Some(username), Some(password)) => Authentication::basic(username, password),
@@ -44,6 +49,11 @@ async fn strategy_registry(opts: &Options) -> Result<()> {
 }
 
 async fn strategy_daemon(opts: &Options) -> Result<()> {
+    if opts.target.is_path() {
+        debug!("input appears to be a file path, skipping strategy");
+        return Ok(());
+    }
+
     let daemon = Daemon::builder()
         .reference(&opts.target.image)
         .build()

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1,3 +1,8 @@
+#![deny(clippy::uninlined_format_args)]
+#![deny(clippy::unwrap_used)]
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+
 use clap::{
     builder::{styling::AnsiColor, Styles},
     Parser,

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -110,7 +110,7 @@ macro_rules! try_strategies {
     ($opts:expr; $($strategy:expr),*) => {{
         $(match $strategy(&$opts).await {
             Ok(()) => return Ok(()),
-            Err(err) => tracing::warn!(?err, "unable to list files"),
+            Err(err) => tracing::warn!(?err, "strategy failed"),
         })*
 
         color_eyre::eyre::bail!("all strategies failed")

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -101,7 +101,7 @@ fn style() -> Styles {
         .valid(AnsiColor::Blue.on_default())
 }
 
-/// Try a list of asynchronous stratgies in sequence.
+/// Try a list of asynchronous strategies in sequence.
 /// The first strategy to succeed stops executing the rest.
 /// If all strategies fail, an error is returned.
 #[macro_export]

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -102,8 +102,11 @@ fn style() -> Styles {
 }
 
 /// Try a list of asynchronous strategies in sequence.
+///
 /// The first strategy to succeed with [`Outcome::Success`] stops executing the rest.
-/// If all strategies fail, an error is returned.
+/// If all strategies fail, an error is returned
+///
+/// Note: this macro returns from the calling context, not from the current expression.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! try_strategies {

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -100,3 +100,19 @@ fn style() -> Styles {
         .invalid(AnsiColor::Red.on_default())
         .valid(AnsiColor::Blue.on_default())
 }
+
+/// Try a list of asynchronous stratgies in sequence.
+/// The first strategy to succeed stops executing the rest.
+/// If all strategies fail, an error is returned.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! try_strategies {
+    ($opts:expr; $($strategy:expr),*) => {{
+        $(match $strategy(&$opts).await {
+            Ok(()) => return Ok(()),
+            Err(err) => tracing::warn!(?err, "unable to list files"),
+        })*
+
+        color_eyre::eyre::bail!("all strategies failed")
+    }}
+}

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -74,7 +74,7 @@ pub async fn main(opts: Options) -> Result<()> {
     // - https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L74
 
     let digest = registry.digest().await.context("get image digest")?;
-    let tag = format!("{}:{}", reference.name(), reference.version);
+    let tag = format!("{}:{}", reference.name, reference.version);
 
     // It's a lot less error prone to use the disk as working state for the tarball we create:
     // the `tokio-tar` library automatically creates a lot of metadata for us if it can use an on-disk artifact

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -34,7 +34,7 @@ pub async fn main(opts: Options) -> Result<()> {
 }
 
 async fn strategy_registry(opts: &Options) -> Result<Outcome> {
-    if opts.target.is_path() {
+    if opts.target.is_path().await {
         debug!("input appears to be a file path, skipping strategy");
         return Ok(Outcome::Skipped);
     }
@@ -61,7 +61,7 @@ async fn strategy_registry(opts: &Options) -> Result<Outcome> {
 }
 
 async fn strategy_daemon(opts: &Options) -> Result<Outcome> {
-    if opts.target.is_path() {
+    if opts.target.is_path().await {
         debug!("input appears to be a file path, skipping strategy");
         return Ok(Outcome::Skipped);
     }

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -30,7 +30,7 @@ pub struct Options {
 #[tracing::instrument]
 pub async fn main(opts: Options) -> Result<()> {
     info!("re-exporting image for FOSSA CLI");
-    try_strategies!(&opts; strategy_registry, strategy_daemon, strategy_tarball)
+    try_strategies!(&opts; strategy_tarball, strategy_daemon, strategy_registry)
 }
 
 async fn strategy_registry(opts: &Options) -> Result<()> {
@@ -49,7 +49,9 @@ async fn strategy_registry(opts: &Options) -> Result<()> {
         .await
         .context("configure remote registry")?;
 
-    reexport(opts, tag, registry).await.context("list files")
+    reexport(opts, tag, registry)
+        .await
+        .context("reexporting image")
 }
 
 async fn strategy_daemon(opts: &Options) -> Result<()> {
@@ -61,7 +63,9 @@ async fn strategy_daemon(opts: &Options) -> Result<()> {
         .context("build daemon reference")?;
 
     tracing::info!("pulled image from daemon");
-    reexport(opts, tag, daemon).await.context("list files")
+    reexport(opts, tag, daemon)
+        .await
+        .context("reexporting image")
 }
 
 async fn strategy_tarball(opts: &Options) -> Result<()> {
@@ -85,8 +89,10 @@ async fn strategy_tarball(opts: &Options) -> Result<()> {
     let digest = tarball.digest().await.context("get image digest")?.as_hex();
     let tag = format!("{name}:{digest}");
 
-    tracing::info!("pulled image from daemon");
-    reexport(opts, tag, tarball).await.context("list files")
+    tracing::info!("using local tarball");
+    reexport(opts, tag, tarball)
+        .await
+        .context("reexporting image")
 }
 
 #[tracing::instrument]

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -14,7 +14,7 @@ use tap::Pipe;
 use tokio_tar::Builder;
 use tracing::{debug, info, warn};
 
-use crate::{extract::Target, try_strategies};
+use crate::{extract::Target, try_strategies, Outcome};
 
 #[derive(Debug, Parser)]
 pub struct Options {
@@ -33,10 +33,10 @@ pub async fn main(opts: Options) -> Result<()> {
     try_strategies!(&opts; strategy_tarball, strategy_daemon, strategy_registry)
 }
 
-async fn strategy_registry(opts: &Options) -> Result<()> {
+async fn strategy_registry(opts: &Options) -> Result<Outcome> {
     if opts.target.is_path() {
         debug!("input appears to be a file path, skipping strategy");
-        return Ok(());
+        return Ok(Outcome::Skipped);
     }
 
     let reference = Reference::from_str(&opts.target.image)?;
@@ -57,12 +57,13 @@ async fn strategy_registry(opts: &Options) -> Result<()> {
     reexport(opts, tag, registry)
         .await
         .context("reexporting image")
+        .map(|_| Outcome::Success)
 }
 
-async fn strategy_daemon(opts: &Options) -> Result<()> {
+async fn strategy_daemon(opts: &Options) -> Result<Outcome> {
     if opts.target.is_path() {
         debug!("input appears to be a file path, skipping strategy");
-        return Ok(());
+        return Ok(Outcome::Skipped);
     }
 
     let tag = opts.target.image.clone();
@@ -76,9 +77,10 @@ async fn strategy_daemon(opts: &Options) -> Result<()> {
     reexport(opts, tag, daemon)
         .await
         .context("reexporting image")
+        .map(|_| Outcome::Success)
 }
 
-async fn strategy_tarball(opts: &Options) -> Result<()> {
+async fn strategy_tarball(opts: &Options) -> Result<Outcome> {
     let path = PathBuf::from(&opts.target.image);
     if matches!(tokio::fs::try_exists(&path).await, Err(_) | Ok(false)) {
         bail!("path does not exist: {path:?}");
@@ -105,6 +107,7 @@ async fn strategy_tarball(opts: &Options) -> Result<()> {
     reexport(opts, tag, tarball)
         .await
         .context("reexporting image")
+        .map(|_| Outcome::Success)
 }
 
 #[tracing::instrument]

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -12,7 +12,7 @@ use pluralizer::pluralize;
 use std::{path::PathBuf, str::FromStr};
 use tap::Pipe;
 use tokio_tar::Builder;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{extract::Target, try_strategies};
 

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -1,19 +1,20 @@
 use async_tempfile::TempFile;
 use circe_lib::{
+    docker::{Daemon, Tarball},
     fossacli::{Image, Manifest, ManifestEntry, RootFs},
     registry::Registry,
     Authentication, Digest, Reference, Source,
 };
 use clap::Parser;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{bail, Context, Result};
 use derive_more::Debug;
 use pluralizer::pluralize;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 use tap::Pipe;
 use tokio_tar::Builder;
 use tracing::{info, warn};
 
-use crate::extract::Target;
+use crate::{extract::Target, try_strategies};
 
 #[derive(Debug, Parser)]
 pub struct Options {
@@ -29,21 +30,67 @@ pub struct Options {
 #[tracing::instrument]
 pub async fn main(opts: Options) -> Result<()> {
     info!("re-exporting image for FOSSA CLI");
+    try_strategies!(&opts; strategy_registry, strategy_daemon, strategy_tarball)
+}
 
+async fn strategy_registry(opts: &Options) -> Result<()> {
     let reference = Reference::from_str(&opts.target.image)?;
-    let auth = match (opts.target.username, opts.target.password) {
+    let auth = match (&opts.target.username, &opts.target.password) {
         (Some(username), Some(password)) => Authentication::basic(username, password),
         _ => Authentication::docker(&reference).await?,
     };
 
+    let tag = format!("{}:{}", reference.name, reference.version);
     let registry = Registry::builder()
-        .maybe_platform(opts.target.platform)
+        .maybe_platform(opts.target.platform.as_ref())
         .reference(reference.clone())
         .auth(auth)
         .build()
         .await
         .context("configure remote registry")?;
 
+    reexport(opts, tag, registry).await.context("list files")
+}
+
+async fn strategy_daemon(opts: &Options) -> Result<()> {
+    let tag = opts.target.image.clone();
+    let daemon = Daemon::builder()
+        .reference(&tag)
+        .build()
+        .await
+        .context("build daemon reference")?;
+
+    tracing::info!("pulled image from daemon");
+    reexport(opts, tag, daemon).await.context("list files")
+}
+
+async fn strategy_tarball(opts: &Options) -> Result<()> {
+    let path = PathBuf::from(&opts.target.image);
+    if matches!(tokio::fs::try_exists(&path).await, Err(_) | Ok(false)) {
+        bail!("path does not exist: {path:?}");
+    }
+
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| opts.target.image.clone().into())
+        .to_string();
+    let tarball = Tarball::builder()
+        .path(path)
+        .name(&name)
+        .build()
+        .await
+        .context("build tarball reference")?;
+
+    let digest = tarball.digest().await.context("get image digest")?.as_hex();
+    let tag = format!("{name}:{digest}");
+
+    tracing::info!("pulled image from daemon");
+    reexport(opts, tag, tarball).await.context("list files")
+}
+
+#[tracing::instrument]
+async fn reexport(opts: &Options, tag: String, registry: impl Source) -> Result<()> {
     let layers = registry.layers().await.context("list layers")?;
     let count = layers.len();
     info!("enumerated {}", pluralize("layer", count as isize, true));
@@ -72,16 +119,14 @@ pub async fn main(opts: Options) -> Result<()> {
     //
     // It then builds a representation of the image based on the combination of these two files:
     // - https://github.com/fossas/fossa-cli/blob/65046d8b1935a2693e6f30869afbc2efb868352e/src/Container/Tarball.hs#L74
-
-    let digest = registry.digest().await.context("get image digest")?;
-    let tag = format!("{}:{}", reference.name, reference.version);
-
+    //
     // It's a lot less error prone to use the disk as working state for the tarball we create:
     // the `tokio-tar` library automatically creates a lot of metadata for us if it can use an on-disk artifact
     // which we'd otherwise be stuck recreating.
     //
     // While this comes at the cost of a little more IO (we're indirecting through the disk)
     // I think this is worth the cost unless it demonstrates to the contrary..
+    let digest = registry.digest().await.context("get image digest")?;
     let tarball = TempFile::new().await.context("create tarball")?;
     let mut tarball = Builder::new(tarball);
     let mut written = Vec::new();

--- a/bin/src/reexport.rs
+++ b/bin/src/reexport.rs
@@ -2,7 +2,7 @@ use async_tempfile::TempFile;
 use circe_lib::{
     fossacli::{Image, Manifest, ManifestEntry, RootFs},
     registry::Registry,
-    Authentication, Digest, Reference,
+    Authentication, Digest, Reference, Source,
 };
 use clap::Parser;
 use color_eyre::eyre::{Context, Result};

--- a/integration/tests/it/extract.rs
+++ b/integration/tests/it/extract.rs
@@ -1,0 +1,84 @@
+use assert_fs::prelude::*;
+use color_eyre::{Result, eyre::Context};
+use simple_test_case::test_case;
+use xshell::{Shell, cmd};
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn daemon(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.path().to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, target = %output, "run circe extract");
+    cmd!(sh, "cargo run -- extract {image} {output} -o").run()?;
+
+    Ok(())
+}
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn pull_and_save(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.child("image.tar").to_string_lossy().to_string();
+    let target = temp.child("target").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, output, "pull and save image");
+    cmd!(sh, "docker pull {image}").run()?;
+    cmd!(sh, "docker save {image} -o {output}").run()?;
+
+    tracing::info!(image, output, "run circe extract");
+    cmd!(sh, "cargo run -- extract {output} {target}").run()?;
+
+    Ok(())
+}
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn oci_registry(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.path().to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_DAEMON_DOCKER", "true");
+
+    tracing::info!(image, target = %output, "run circe extract");
+    cmd!(sh, "cargo run -- extract {image} {output} -o").run()?;
+
+    Ok(())
+}

--- a/integration/tests/it/extract.rs
+++ b/integration/tests/it/extract.rs
@@ -8,11 +8,10 @@ use xshell::{Shell, cmd};
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[ignore = "this doesn't seem to work in CI, although it works locally"]
-// #[cfg_attr(
-//     not(all(feature = "test-integration", feature = "test-docker-interop")),
-//     ignore = "skipping integration tests that require docker to be installed"
-// )]
+#[cfg_attr(
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
+)]
 async fn daemon(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
@@ -34,11 +33,10 @@ async fn daemon(image: &str) -> Result<()> {
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[ignore = "this doesn't seem to work in CI, although it works locally"]
-// #[cfg_attr(
-//     not(all(feature = "test-integration", feature = "test-docker-interop")),
-//     ignore = "skipping integration tests that require docker to be installed"
-// )]
+#[cfg_attr(
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
+)]
 async fn pull_and_save(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;

--- a/integration/tests/it/extract.rs
+++ b/integration/tests/it/extract.rs
@@ -9,8 +9,8 @@ use xshell::{Shell, cmd};
 )]
 #[test_log::test(tokio::test)]
 #[cfg_attr(
-    not(feature = "test-integration"),
-    ignore = "skipping integration tests"
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
 )]
 async fn daemon(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
@@ -34,8 +34,8 @@ async fn daemon(image: &str) -> Result<()> {
 )]
 #[test_log::test(tokio::test)]
 #[cfg_attr(
-    not(feature = "test-integration"),
-    ignore = "skipping integration tests"
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
 )]
 async fn pull_and_save(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();

--- a/integration/tests/it/extract.rs
+++ b/integration/tests/it/extract.rs
@@ -8,10 +8,11 @@ use xshell::{Shell, cmd};
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[cfg_attr(
-    not(all(feature = "test-integration", feature = "test-docker-interop")),
-    ignore = "skipping integration tests that require docker to be installed"
-)]
+#[ignore = "this doesn't seem to work in CI, although it works locally"]
+// #[cfg_attr(
+//     not(all(feature = "test-integration", feature = "test-docker-interop")),
+//     ignore = "skipping integration tests that require docker to be installed"
+// )]
 async fn daemon(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
@@ -33,10 +34,11 @@ async fn daemon(image: &str) -> Result<()> {
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[cfg_attr(
-    not(all(feature = "test-integration", feature = "test-docker-interop")),
-    ignore = "skipping integration tests that require docker to be installed"
-)]
+#[ignore = "this doesn't seem to work in CI, although it works locally"]
+// #[cfg_attr(
+//     not(all(feature = "test-integration", feature = "test-docker-interop")),
+//     ignore = "skipping integration tests that require docker to be installed"
+// )]
 async fn pull_and_save(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;

--- a/integration/tests/it/list.rs
+++ b/integration/tests/it/list.rs
@@ -1,0 +1,83 @@
+use assert_fs::prelude::*;
+use color_eyre::{Result, eyre::Context};
+use simple_test_case::test_case;
+use xshell::{Shell, cmd};
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn daemon(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.path().to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, target = %output, "run circe list");
+    cmd!(sh, "cargo run -- list {image}").run()?;
+
+    Ok(())
+}
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn pull_and_save(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.child("image.tar").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, output, "pull and save image");
+    cmd!(sh, "docker pull {image}").run()?;
+    cmd!(sh, "docker save {image} -o {output}").run()?;
+
+    tracing::info!(image, output, "run circe list");
+    cmd!(sh, "cargo run -- list {output}").run()?;
+
+    Ok(())
+}
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn oci_registry(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.path().to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_DAEMON_DOCKER", "true");
+
+    tracing::info!(image, target = %output, "run circe list");
+    cmd!(sh, "cargo run -- list {image}").run()?;
+
+    Ok(())
+}

--- a/integration/tests/it/list.rs
+++ b/integration/tests/it/list.rs
@@ -8,11 +8,10 @@ use xshell::{Shell, cmd};
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[ignore = "this doesn't seem to work in CI, although it works locally"]
-// #[cfg_attr(
-//     not(all(feature = "test-integration", feature = "test-docker-interop")),
-//     ignore = "skipping integration tests that require docker to be installed"
-// )]
+#[cfg_attr(
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
+)]
 async fn daemon(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
@@ -34,11 +33,10 @@ async fn daemon(image: &str) -> Result<()> {
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[ignore = "this doesn't seem to work in CI, although it works locally"]
-// #[cfg_attr(
-//     not(all(feature = "test-integration", feature = "test-docker-interop")),
-//     ignore = "skipping integration tests that require docker to be installed"
-// )]
+#[cfg_attr(
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
+)]
 async fn pull_and_save(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;

--- a/integration/tests/it/list.rs
+++ b/integration/tests/it/list.rs
@@ -9,8 +9,8 @@ use xshell::{Shell, cmd};
 )]
 #[test_log::test(tokio::test)]
 #[cfg_attr(
-    not(feature = "test-integration"),
-    ignore = "skipping integration tests"
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
 )]
 async fn daemon(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
@@ -34,8 +34,8 @@ async fn daemon(image: &str) -> Result<()> {
 )]
 #[test_log::test(tokio::test)]
 #[cfg_attr(
-    not(feature = "test-integration"),
-    ignore = "skipping integration tests"
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
 )]
 async fn pull_and_save(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();

--- a/integration/tests/it/list.rs
+++ b/integration/tests/it/list.rs
@@ -8,10 +8,11 @@ use xshell::{Shell, cmd};
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[cfg_attr(
-    not(all(feature = "test-integration", feature = "test-docker-interop")),
-    ignore = "skipping integration tests that require docker to be installed"
-)]
+#[ignore = "this doesn't seem to work in CI, although it works locally"]
+// #[cfg_attr(
+//     not(all(feature = "test-integration", feature = "test-docker-interop")),
+//     ignore = "skipping integration tests that require docker to be installed"
+// )]
 async fn daemon(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
@@ -33,10 +34,11 @@ async fn daemon(image: &str) -> Result<()> {
     "nginx:latest"
 )]
 #[test_log::test(tokio::test)]
-#[cfg_attr(
-    not(all(feature = "test-integration", feature = "test-docker-interop")),
-    ignore = "skipping integration tests that require docker to be installed"
-)]
+#[ignore = "this doesn't seem to work in CI, although it works locally"]
+// #[cfg_attr(
+//     not(all(feature = "test-integration", feature = "test-docker-interop")),
+//     ignore = "skipping integration tests that require docker to be installed"
+// )]
 async fn pull_and_save(image: &str) -> Result<()> {
     let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;

--- a/integration/tests/it/main.rs
+++ b/integration/tests/it/main.rs
@@ -1,1 +1,3 @@
+mod extract;
+mod list;
 mod reexport;

--- a/integration/tests/it/main.rs
+++ b/integration/tests/it/main.rs
@@ -1,3 +1,13 @@
+use std::path::PathBuf;
+
 mod extract;
 mod list;
 mod reexport;
+
+/// The root directory of the workspace.
+pub fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}

--- a/integration/tests/it/reexport.rs
+++ b/integration/tests/it/reexport.rs
@@ -133,6 +133,7 @@ async fn daemon(image: &str) -> Result<()> {
     let sh = Shell::new().context("create shell")?;
     sh.change_dir(&workspace);
     sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+    sh.set_var("RUST_LOG", "debug");
 
     tracing::info!(image, "pull image");
     cmd!(sh, "docker pull {image}").run()?;
@@ -175,6 +176,7 @@ async fn pull_and_save(image: &str) -> Result<()> {
     let sh = Shell::new().context("create shell")?;
     sh.change_dir(&workspace);
     sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+    sh.set_var("RUST_LOG", "debug");
 
     tracing::info!(image, output, "pull and save image");
     cmd!(sh, "docker pull {image}").run()?;

--- a/integration/tests/it/reexport.rs
+++ b/integration/tests/it/reexport.rs
@@ -7,6 +7,94 @@ use serde_json::Value;
 use simple_test_case::test_case;
 use xshell::{Shell, cmd};
 
+/// Test that `circe reexport` then allows FOSSA CLI to scan
+/// tarballs that have been saved locally with `docker pull $IMAGE && docker save $IMAGE`.
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn daemon(image: &str) -> Result<()> {
+    let workspace = workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, "pull image");
+    cmd!(sh, "docker pull {image}").run()?;
+
+    tracing::info!(image, target = %reexport, "run circe reexport");
+    cmd!(sh, "cargo run -- reexport {image} {reexport}").run()?;
+
+    tracing::info!(target = %reexport, "run fossa container analyze");
+    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
+
+    tracing::info!(target = %reexport, "read cli output");
+    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
+
+    // We don't have any images to compare, so we cannot do much in the way of assertions on the object.
+    // But at minimum, we can expect that the image should have contained layers.
+    assert!(
+        !reexport_output.image.layers.is_empty(),
+        "reexported image should have layers"
+    );
+
+    Ok(())
+}
+
+/// Test that `circe reexport` then allows FOSSA CLI to scan
+/// tarballs that have been saved locally with `docker pull $IMAGE && docker save $IMAGE`.
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(feature = "test-integration"),
+    ignore = "skipping integration tests"
+)]
+async fn pull_and_save(image: &str) -> Result<()> {
+    let workspace = workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.child("image.tar").to_string_lossy().to_string();
+    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, output, "pull and save image");
+    cmd!(sh, "docker pull {image}").run()?;
+    cmd!(sh, "docker save {image} -o {output}").run()?;
+
+    tracing::info!(image, output, target = %reexport, "run circe reexport");
+    cmd!(sh, "cargo run -- reexport {output} {reexport}").run()?;
+
+    tracing::info!(target = %reexport, "run fossa container analyze");
+    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
+
+    tracing::info!(target = %reexport, "read cli output");
+    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
+
+    // We don't have any images to compare, so we cannot do much in the way of assertions on the object.
+    // But at minimum, we can expect that the image should have contained layers.
+    assert!(
+        !reexport_output.image.layers.is_empty(),
+        "reexported image should have layers"
+    );
+
+    Ok(())
+}
+
 /// Test that `circe reexport` then allows FOSSA CLI to scan images
 /// that have previously been ticketed as failing to be analyzed.
 #[test_case(
@@ -42,6 +130,7 @@ async fn scannable(image: &str) -> Result<()> {
     tracing::info!(workspace = %workspace.display(), "create shell");
     let sh = Shell::new().context("create shell")?;
     sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_DAEMON_DOCKER", "true");
 
     tracing::info!(image, target = %reexport, "run circe reexport");
     cmd!(sh, "cargo run -- reexport {image} {reexport}").run()?;
@@ -96,6 +185,7 @@ async fn compare(image: &str, reference: &str) -> Result<()> {
     tracing::info!(workspace = %workspace.display(), "create shell");
     let sh = Shell::new().context("create shell")?;
     sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_DAEMON_DOCKER", "true");
 
     tracing::info!(image, target = %reexport, "run circe reexport");
     cmd!(sh, "cargo run -- reexport {image} {reexport}").run()?;

--- a/integration/tests/it/reexport.rs
+++ b/integration/tests/it/reexport.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::collections::HashSet;
 
 use assert_fs::prelude::*;
 use color_eyre::{Result, eyre::Context};
@@ -7,8 +7,6 @@ use serde_json::Value;
 use simple_test_case::test_case;
 use xshell::{Shell, cmd};
 
-/// Test that `circe reexport` then allows FOSSA CLI to scan
-/// tarballs that have been saved locally with `docker pull $IMAGE && docker save $IMAGE`.
 #[test_case(
     "nginx:latest";
     "nginx:latest"
@@ -19,7 +17,7 @@ use xshell::{Shell, cmd};
     ignore = "skipping integration tests"
 )]
 async fn daemon(image: &str) -> Result<()> {
-    let workspace = workspace_root();
+    let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
     let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
 
@@ -50,8 +48,6 @@ async fn daemon(image: &str) -> Result<()> {
     Ok(())
 }
 
-/// Test that `circe reexport` then allows FOSSA CLI to scan
-/// tarballs that have been saved locally with `docker pull $IMAGE && docker save $IMAGE`.
 #[test_case(
     "nginx:latest";
     "nginx:latest"
@@ -62,7 +58,7 @@ async fn daemon(image: &str) -> Result<()> {
     ignore = "skipping integration tests"
 )]
 async fn pull_and_save(image: &str) -> Result<()> {
-    let workspace = workspace_root();
+    let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
     let output = temp.child("image.tar").to_string_lossy().to_string();
     let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
@@ -123,7 +119,7 @@ async fn pull_and_save(image: &str) -> Result<()> {
     ignore = "skipping integration tests"
 )]
 async fn scannable(image: &str) -> Result<()> {
-    let workspace = workspace_root();
+    let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
     let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
 
@@ -178,7 +174,7 @@ async fn scannable(image: &str) -> Result<()> {
     ignore = "skipping integration tests that require docker to be installed"
 )]
 async fn compare(image: &str, reference: &str) -> Result<()> {
-    let workspace = workspace_root();
+    let workspace = crate::workspace_root();
     let temp = assert_fs::TempDir::new().context("create temp dir")?;
     let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
 
@@ -227,11 +223,4 @@ struct CliContainerImage {
 struct CliContainerLayer {
     observations: HashSet<Value>,
     src_units: HashSet<Value>,
-}
-
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
 }

--- a/integration/tests/it/reexport.rs
+++ b/integration/tests/it/reexport.rs
@@ -7,90 +7,6 @@ use serde_json::Value;
 use simple_test_case::test_case;
 use xshell::{Shell, cmd};
 
-#[test_case(
-    "nginx:latest";
-    "nginx:latest"
-)]
-#[test_log::test(tokio::test)]
-#[cfg_attr(
-    not(feature = "test-integration"),
-    ignore = "skipping integration tests"
-)]
-async fn daemon(image: &str) -> Result<()> {
-    let workspace = crate::workspace_root();
-    let temp = assert_fs::TempDir::new().context("create temp dir")?;
-    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
-
-    tracing::info!(workspace = %workspace.display(), "create shell");
-    let sh = Shell::new().context("create shell")?;
-    sh.change_dir(&workspace);
-    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
-
-    tracing::info!(image, "pull image");
-    cmd!(sh, "docker pull {image}").run()?;
-
-    tracing::info!(image, target = %reexport, "run circe reexport");
-    cmd!(sh, "cargo run -- reexport {image} {reexport}").run()?;
-
-    tracing::info!(target = %reexport, "run fossa container analyze");
-    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
-
-    tracing::info!(target = %reexport, "read cli output");
-    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
-
-    // We don't have any images to compare, so we cannot do much in the way of assertions on the object.
-    // But at minimum, we can expect that the image should have contained layers.
-    assert!(
-        !reexport_output.image.layers.is_empty(),
-        "reexported image should have layers"
-    );
-
-    Ok(())
-}
-
-#[test_case(
-    "nginx:latest";
-    "nginx:latest"
-)]
-#[test_log::test(tokio::test)]
-#[cfg_attr(
-    not(feature = "test-integration"),
-    ignore = "skipping integration tests"
-)]
-async fn pull_and_save(image: &str) -> Result<()> {
-    let workspace = crate::workspace_root();
-    let temp = assert_fs::TempDir::new().context("create temp dir")?;
-    let output = temp.child("image.tar").to_string_lossy().to_string();
-    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
-
-    tracing::info!(workspace = %workspace.display(), "create shell");
-    let sh = Shell::new().context("create shell")?;
-    sh.change_dir(&workspace);
-    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
-
-    tracing::info!(image, output, "pull and save image");
-    cmd!(sh, "docker pull {image}").run()?;
-    cmd!(sh, "docker save {image} -o {output}").run()?;
-
-    tracing::info!(image, output, target = %reexport, "run circe reexport");
-    cmd!(sh, "cargo run -- reexport {output} {reexport}").run()?;
-
-    tracing::info!(target = %reexport, "run fossa container analyze");
-    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
-
-    tracing::info!(target = %reexport, "read cli output");
-    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
-
-    // We don't have any images to compare, so we cannot do much in the way of assertions on the object.
-    // But at minimum, we can expect that the image should have contained layers.
-    assert!(
-        !reexport_output.image.layers.is_empty(),
-        "reexported image should have layers"
-    );
-
-    Ok(())
-}
-
 /// Test that `circe reexport` then allows FOSSA CLI to scan images
 /// that have previously been ticketed as failing to be analyzed.
 #[test_case(
@@ -195,6 +111,90 @@ async fn compare(image: &str, reference: &str) -> Result<()> {
     let reference_output = serde_json::from_str::<CliContainerOutput>(&reference_output)?;
 
     pretty_assertions::assert_eq!(reference_output, reexport_output);
+
+    Ok(())
+}
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
+)]
+async fn daemon(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, "pull image");
+    cmd!(sh, "docker pull {image}").run()?;
+
+    tracing::info!(image, target = %reexport, "run circe reexport");
+    cmd!(sh, "cargo run -- reexport {image} {reexport}").run()?;
+
+    tracing::info!(target = %reexport, "run fossa container analyze");
+    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
+
+    tracing::info!(target = %reexport, "read cli output");
+    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
+
+    // We don't have any images to compare, so we cannot do much in the way of assertions on the object.
+    // But at minimum, we can expect that the image should have contained layers.
+    assert!(
+        !reexport_output.image.layers.is_empty(),
+        "reexported image should have layers"
+    );
+
+    Ok(())
+}
+
+#[test_case(
+    "nginx:latest";
+    "nginx:latest"
+)]
+#[test_log::test(tokio::test)]
+#[cfg_attr(
+    not(all(feature = "test-integration", feature = "test-docker-interop")),
+    ignore = "skipping integration tests that require docker to be installed"
+)]
+async fn pull_and_save(image: &str) -> Result<()> {
+    let workspace = crate::workspace_root();
+    let temp = assert_fs::TempDir::new().context("create temp dir")?;
+    let output = temp.child("image.tar").to_string_lossy().to_string();
+    let reexport = temp.child("reexport.tar").to_string_lossy().to_string();
+
+    tracing::info!(workspace = %workspace.display(), "create shell");
+    let sh = Shell::new().context("create shell")?;
+    sh.change_dir(&workspace);
+    sh.set_var("CIRCE_DISABLE_REGISTRY_OCI", "true");
+
+    tracing::info!(image, output, "pull and save image");
+    cmd!(sh, "docker pull {image}").run()?;
+    cmd!(sh, "docker save {image} -o {output}").run()?;
+
+    tracing::info!(image, output, target = %reexport, "run circe reexport");
+    cmd!(sh, "cargo run -- reexport {output} {reexport}").run()?;
+
+    tracing::info!(target = %reexport, "run fossa container analyze");
+    let reexport_output = cmd!(sh, "fossa container analyze {reexport} -o").read()?;
+
+    tracing::info!(target = %reexport, "read cli output");
+    let reexport_output = serde_json::from_str::<CliContainerOutput>(&reexport_output)?;
+
+    // We don't have any images to compare, so we cannot do much in the way of assertions on the object.
+    // But at minimum, we can expect that the image should have contained layers.
+    assert!(
+        !reexport_output.image.layers.is_empty(),
+        "reexported image should have layers"
+    );
 
     Ok(())
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -45,6 +45,10 @@ tokio-tar = "0.3.1"
 tokio-util = { version = "0.7.13", features = ["io"] }
 tracing = "0.1.41"
 sha2 = "0.10.8"
+bollard = "0.18.1"
+enum_delegate = "0.2.0"
+enum_dispatch = "0.3.13"
+async-stream = "0.3.6"
 
 [dev-dependencies]
 async-walkdir = "2.0.0"

--- a/lib/src/cfs.rs
+++ b/lib/src/cfs.rs
@@ -1,0 +1,298 @@
+//! Container file system operations.
+
+use std::path::{Path, PathBuf};
+
+use async_tempfile::TempFile;
+use bytes::Bytes;
+use color_eyre::{
+    eyre::{Context, OptionExt},
+    Result,
+};
+use futures_lite::{Stream, StreamExt};
+use os_str_bytes::OsStrBytesExt;
+use tap::Pipe;
+use tokio::io::{AsyncRead, AsyncWriteExt, BufWriter};
+use tokio_tar::{Archive, Entry};
+use tokio_util::io::StreamReader;
+use tracing::{debug, warn};
+
+use crate::{transform::Chunk, FilterMatch, Filters};
+
+/// Unwrap a value, logging an error and performing the provided action if it fails.
+macro_rules! unwrap_warn {
+    ($expr:expr, $action:expr) => {
+        unwrap_warn!($expr, $action,)
+    };
+    ($expr:expr, $action:expr, $($msg:tt)*) => {
+        match $expr {
+            Ok(value) => value,
+            Err(e) => {
+                tracing::warn!(error = ?e, $($msg)*);
+                $action;
+            }
+        }
+    };
+}
+
+/// Sink the stream into a temporary file.
+pub async fn collect_tmp<E: std::error::Error + Send + Sync + 'static>(
+    mut stream: impl Stream<Item = Result<Bytes, E>> + Unpin,
+) -> Result<TempFile> {
+    let file = TempFile::new().await.context("create temp file")?;
+    let mut writer = BufWriter::new(file);
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("read chunk")?;
+        writer.write_all(&chunk).await.context("write chunk")?;
+    }
+    writer.flush().await.context("flush writer")?;
+
+    let file = writer.into_inner();
+    file.sync_all().await.context("sync file")?;
+    Ok(file)
+}
+
+/// Apply a layer diff tarball to a location on disk.
+pub async fn apply_tarball(
+    path_filters: &Filters,
+    stream: impl Stream<Item = Chunk> + Unpin,
+    output: &Path,
+) -> Result<()> {
+    let reader = StreamReader::new(stream);
+    let mut archive = Archive::new(reader);
+    let mut entries = archive.entries().context("read entries from tar")?;
+
+    // Future improvement: the OCI spec guarantees that paths will not repeat within the same layer,
+    // so we could concurrently read files and apply them to disk.
+    // The overall archive is streaming so we'd need to buffer the entries,
+    // but assuming disk is the bottleneck this might speed up the process significantly.
+    // We could also of course write the tar to disk and then extract it concurrently
+    // without buffering- maybe we could read the tar entries while streaming to disk,
+    // and then divide them among workers that apply them to disk concurrently?
+    while let Some(entry) = entries.next().await {
+        let mut entry = unwrap_warn!(entry, continue, "read entry");
+        let path = unwrap_warn!(entry.path(), continue, "read entry path");
+
+        // Paths inside the container are relative to the root of the container;
+        // we need to convert them to be relative to the output directory.
+        let path = output.join(path);
+
+        if !path_filters.matches(&path) {
+            debug!(?path, "skip: path filter");
+            continue;
+        }
+
+        // Whiteout files delete the file from the filesystem.
+        if let Some(path) = is_whiteout(&path) {
+            unwrap_warn!(
+                tokio::fs::remove_file(&path).await,
+                continue,
+                "whiteout: {path:?}"
+            );
+            debug!(?path, "whiteout");
+            continue;
+        }
+
+        // The tar library mostly handles symlinks properly, but still allows them to link to absolute paths.
+        // This doesn't technically break anything from a security standpoint, but might for analysis.
+        // Intercept its handling of absolute symlinks to handle this case.
+        if entry.header().entry_type().is_symlink() {
+            let handled = unwrap_warn!(
+                safe_symlink(&entry, output).await,
+                continue,
+                "create symlink {path:?}"
+            );
+
+            // But if the function didn't handle it, fall back to the default behavior.
+            if handled {
+                continue;
+            }
+        }
+
+        // Future improvement: symlinks are unpacked with the same destination as written in the actual container;
+        // this means e.g. they can link to files outside of the output directory
+        // (the example case I found was in `usr/bin`, linking to `/bin/`).
+        // I don't _think_ this matters for now given how we're using this today, but it's technically incorrect.
+        // To fix this we need to re-implement the logic in `unpack_in` to rewrite symlink destinations.
+
+        // Otherwise, apply the file as normal.
+        // Both _new_ and _changed_ files are handled the same way:
+        // the layer contains the entire file content, so we just overwrite the file.
+        if !unwrap_warn!(entry.unpack_in(output).await, continue, "unpack {path:?}") {
+            warn!(?path, "skip: tried to write outside of output directory");
+            continue;
+        }
+
+        debug!(?path, "apply");
+    }
+
+    Ok(())
+}
+
+/// Enumerate files in a tarball.
+pub async fn enumerate_tarball(stream: impl Stream<Item = Chunk> + Unpin) -> Result<Vec<String>> {
+    let reader = StreamReader::new(stream);
+    let mut archive = Archive::new(reader);
+    let mut entries = archive.entries().context("read entries from tar")?;
+
+    let mut files = Vec::new();
+    while let Some(entry) = entries.next().await {
+        let entry = unwrap_warn!(entry, continue, "read entry");
+        let path = unwrap_warn!(entry.path(), continue, "read entry path");
+        debug!(?path, "enumerate");
+        files.push(path.to_string_lossy().to_string());
+    }
+
+    Ok(files)
+}
+
+/// Special handling for symlinks that link to an absolute path.
+/// It effectively forces the destination into a path relative to the output directory.
+///
+/// Returns true if the symlink was handled;
+/// false if the symlink should fall back to standard handling from `async_tar`.
+pub async fn safe_symlink<R: AsyncRead + Unpin>(entry: &Entry<R>, dir: &Path) -> Result<bool> {
+    let header = entry.header();
+    let kind = header.entry_type();
+    if !kind.is_symlink() {
+        return Ok(false);
+    }
+
+    let link = entry.path().context("read symlink source")?;
+    let target = header
+        .link_name()
+        .context("read symlink target")?
+        .ok_or_eyre("no symlink target")?;
+
+    // If the target is relative, we should let `async_tar` handle it;
+    // this function only needs to intercept absolute symlinks.
+    if !target.is_absolute() {
+        return Ok(false);
+    }
+
+    let safe_link = dir.join(&link);
+    let safe_target = dir.join(strip_root(&target));
+
+    let rel_target = compute_symlink_target(&safe_link, &safe_target)
+        .with_context(|| format!("compute relative path from {safe_link:?} to {safe_target:?}"))?;
+    debug!(
+        ?link,
+        ?target,
+        ?safe_link,
+        ?safe_target,
+        ?rel_target,
+        "create symlink"
+    );
+
+    if let Some(parent) = safe_link.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .context("create parent directory")?;
+    }
+
+    symlink(&rel_target, &safe_link)
+        .await
+        .map(|_| true)
+        .with_context(|| {
+            format!("create symlink from {safe_link:?} to {safe_target:?} as {rel_target:?}")
+        })
+}
+
+pub fn compute_symlink_target(src: &Path, dst: &Path) -> Result<PathBuf> {
+    let common_prefix = src
+        .components()
+        .zip(dst.components())
+        .by_ref()
+        .take_while(|(src, dst)| src == dst)
+        .map(|(src, _)| src)
+        .collect::<PathBuf>();
+
+    let src_rel = src
+        .strip_prefix(&common_prefix)
+        .context("strip common prefix from src")?;
+    let dst_rel = dst
+        .strip_prefix(&common_prefix)
+        .context("strip common prefix from dst")?;
+
+    // `bridge` is the path from the source to the common prefix.
+    let bridge = src_rel
+        .components()
+        .skip(1)
+        .map(|_| "..")
+        .collect::<PathBuf>();
+    let rel = bridge.join(dst_rel);
+
+    // `.` indicates that the source and destination are the same file.
+    if rel.to_string_lossy().is_empty() {
+        Ok(PathBuf::from("."))
+    } else {
+        Ok(rel)
+    }
+}
+
+/// Strips any root and prefix from a path, if they exist.
+pub fn strip_root(path: impl AsRef<Path>) -> PathBuf {
+    path.as_ref()
+        .components()
+        .filter(|c| match c {
+            std::path::Component::Prefix(_) => false,
+            std::path::Component::RootDir => false,
+            _ => true,
+        })
+        .pipe(PathBuf::from_iter)
+}
+
+#[cfg(windows)]
+pub async fn symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let (src, dst) = (src.to_owned(), dst.to_owned());
+    tokio::task::spawn_blocking(|| std::os::windows::fs::symlink_file(src, dst))
+        .await
+        .expect("join tokio task")
+}
+
+#[cfg(any(unix, target_os = "redox"))]
+pub async fn symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    tokio::fs::symlink(src, dst).await
+}
+
+/// Returns the path to the file that would be deleted by a whiteout file, if the path is a whiteout file.
+/// If the path is not a whiteout file, returns `None`.
+fn is_whiteout(path: &Path) -> Option<PathBuf> {
+    const WHITEOUT_PREFIX: &str = ".wh.";
+
+    // If the file doesn't have a name, it's not a whiteout file.
+    // Similarly if it doesn't have the prefix, it's also not a whiteout file.
+    let name = path.file_name()?.strip_prefix(WHITEOUT_PREFIX)?;
+    Some(match path.parent() {
+        Some(parent) => PathBuf::from(parent).join(name),
+        None => PathBuf::from(name),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use simple_test_case::test_case;
+
+    #[test]
+    fn test_is_whiteout() {
+        assert_eq!(None, is_whiteout(Path::new("foo")));
+        assert_eq!(
+            Some(PathBuf::from("foo")),
+            is_whiteout(Path::new(".wh.foo")),
+        );
+    }
+
+    #[test_case(Path::new("/a/b/c"), Path::new("/a/b/d/e/f"), PathBuf::from("d/e/f"); "one_level")]
+    #[test_case(Path::new("/usr/local/bin/ls"), Path::new("/bin/ls"), PathBuf::from("../../../bin/ls"); "usr_local_bin_to_bin")]
+    #[test_case(Path::new("/usr/local/bin/ls"), Path::new("/usr/bin/ls"), PathBuf::from("../../bin/ls"); "usr_local_bin_to_usr_bin")]
+    #[test_case(Path::new("/usr/local/bin/ls"), Path::new("/usr/local/bin/ls"), PathBuf::from("."); "same_file")]
+    #[test_case(Path::new("/usr/local/bin/eza"), Path::new("/usr/local/bin/ls"), PathBuf::from("ls"); "same_dir")]
+    #[tokio::test]
+    async fn compute_symlink_target(src: &Path, dst: &Path, expected: PathBuf) -> Result<()> {
+        let relative = compute_symlink_target(src, dst)?;
+        pretty_assertions::assert_eq!(expected, relative);
+        Ok(())
+    }
+}

--- a/lib/src/cfs.rs
+++ b/lib/src/cfs.rs
@@ -234,11 +234,7 @@ pub fn compute_symlink_target(src: &Path, dst: &Path) -> Result<PathBuf> {
 pub fn strip_root(path: impl AsRef<Path>) -> PathBuf {
     path.as_ref()
         .components()
-        .filter(|c| match c {
-            std::path::Component::Prefix(_) => false,
-            std::path::Component::RootDir => false,
-            _ => true,
-        })
+        .filter(|c| !matches!(c, std::path::Component::Prefix(_) | std::path::Component::RootDir))
         .pipe(PathBuf::from_iter)
 }
 

--- a/lib/src/docker.rs
+++ b/lib/src/docker.rs
@@ -3,36 +3,30 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     process::Stdio,
-    str::FromStr,
 };
 
 use crate::{
     cfs::{self, apply_tarball, collect_tmp, enumerate_tarball},
-    ext::PriorityFind,
     homedir,
     transform::{self, Chunk},
-    Authentication, Digest, Filter, FilterMatch, Filters, Layer, LayerMediaType,
-    LayerMediaTypeFlag, Reference, Source, Version,
+    Authentication, Digest, FilterMatch, Filters, Layer, LayerMediaType, LayerMediaTypeFlag,
+    Reference, Source,
 };
 use async_tempfile::TempFile;
 use base64::Engine;
-use bollard::image::RemoveImageOptions;
-use bollard::models::ImageInspect as BollardImageInspect;
-use bollard::service::ImageInspect;
 use bollard::Docker;
-use bollard::{container::RemoveContainerOptions, secret::ImageSummary};
 use bytes::Bytes;
 use color_eyre::{
-    eyre::{bail, ensure, eyre, Context, OptionExt, Result},
+    eyre::{eyre, Context, OptionExt, Result},
     Section, SectionExt,
 };
 use derive_more::Debug;
 use futures_lite::{Stream, StreamExt};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tap::{Pipe, TapFallible};
-use tokio::io::{AsyncRead, AsyncWriteExt, BufWriter};
-use tokio_tar::{Archive, Entry};
-use tokio_util::io::StreamReader;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_tar::Archive;
+use tokio_util::io::ReaderStream;
 use tracing::{debug, info, warn};
 
 impl Authentication {
@@ -99,7 +93,7 @@ struct DockerConfig {
 impl DockerConfig {
     /// Some hosts have fallback keys.
     /// Given a host, this function returns an iterator representing fallback keys to check for authentication.
-    fn auth_keys<'a>(host: &'a str) -> impl Iterator<Item = &'a str> {
+    fn auth_keys(host: &str) -> impl Iterator<Item = &str> {
         if host == "docker.io" {
             vec!["docker.io", "https://index.docker.io/v1/"]
         } else {
@@ -154,7 +148,7 @@ impl DockerAuth {
 
     fn decode_plain(auth: &str) -> Result<Authentication> {
         let auth = base64::engine::general_purpose::STANDARD
-            .decode(&auth)
+            .decode(auth)
             .context("decode base64 auth key")?;
         let auth = String::from_utf8(auth).context("parse auth key as utf-8")?;
         let (username, password) = auth
@@ -220,6 +214,7 @@ struct DockerCredential {
 /// Each instance is a unique view of a local Docker daemon for a specific [`Reference`].
 /// Similar to [`crate::registry::Registry`], but interacts with a local Docker daemon.
 #[derive(Debug)]
+#[allow(unused)]
 pub struct Daemon {
     /// The client used to interact with the docker daemon.
     #[debug(skip)]
@@ -232,11 +227,11 @@ pub struct Daemon {
     exported: TempFile,
 
     /// Layer filters.
-    /// Layers that match any filter are included in the set of layers processed by this daemon.
+    /// Layers that match any filter are excluded from the set of layers processed.
     layer_filters: Filters,
 
     /// File filters.
-    /// Files that match any filter are included in the set of files processed by this daemon.
+    /// Files that match any filter are excluded from the set of files processed.
     file_filters: Filters,
 }
 
@@ -246,12 +241,12 @@ impl Daemon {
     #[builder]
     pub async fn new(
         /// Filters for layers.
-        /// Layers that match any filter are included in the set of layers processed by this daemon.
+        /// Layers that match any filter are excluded from the set of layers processed.
         #[builder(into)]
         layer_filters: Option<Filters>,
 
         /// Filters for files.
-        /// Files that match any filter are included in the set of files processed by this daemon.
+        /// Files that match any filter are excluded from the set of files processed.
         #[builder(into)]
         file_filters: Option<Filters>,
 
@@ -332,6 +327,693 @@ impl Source for Daemon {
 
     async fn name(&self) -> Result<String> {
         Ok(self.image.clone())
+    }
+
+    async fn layers(&self) -> Result<Vec<Layer>> {
+        self.layers().await
+    }
+
+    async fn pull_layer(
+        &self,
+        layer: &Layer,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>> {
+        self.pull_layer(layer).await
+    }
+
+    async fn list_files(&self, layer: &Layer) -> Result<Vec<String>> {
+        self.list_files(layer).await
+    }
+
+    async fn apply_layer(&self, layer: &Layer, output: &Path) -> Result<()> {
+        self.apply_layer(layer, output).await
+    }
+
+    async fn layer_plain_tarball(&self, layer: &Layer) -> Result<Option<TempFile>> {
+        self.layer_plain_tarball(layer).await
+    }
+}
+
+/// Docker tarball manifest file format
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DockerManifest {
+    /// Path to the image configuration file
+    pub config: String,
+
+    /// Repository tags associated with the image
+    #[serde(default)]
+    pub repo_tags: Vec<String>,
+
+    /// Layer tar filenames in order (from base to application)
+    pub layers: Vec<String>,
+}
+
+/// An implementation of [`Source`] that reads from a local docker tarball.
+///
+/// Docker tarballs are created via the `docker save` command and have a specific
+/// structure with a manifest.json file and layer tarballs.
+#[derive(Debug)]
+pub struct Tarball {
+    /// Path to the Docker tarball file
+    path: PathBuf,
+
+    /// The parsed manifest from the tarball
+    manifest: DockerManifest,
+
+    /// Digest computed from the image configuration
+    image_digest: Digest,
+
+    /// Name inferred from the tarball
+    name: String,
+
+    /// Cached list of layers
+    layers: Vec<Layer>,
+
+    /// Layer filters.
+    /// Layers that match any filter are excluded from the set of layers processed.
+    layer_filters: Filters,
+
+    /// File filters.
+    /// Files that match any filter are excluded from the set of files processed.
+    file_filters: Filters,
+}
+
+#[bon::bon]
+impl Tarball {
+    /// Create a new tarball source from a path to a Docker tarball.
+    #[builder]
+    pub async fn new(
+        /// Path to the Docker tarball file
+        #[builder(into)]
+        path: PathBuf,
+
+        /// Filters for layers.
+        /// Layers that match any filter are excluded from the set of layers processed.
+        #[builder(into)]
+        layer_filters: Option<Filters>,
+
+        /// Filters for files.
+        /// Files that match any filter are excluded from the set of files processed.
+        #[builder(into)]
+        file_filters: Option<Filters>,
+    ) -> Result<Self> {
+        if !path.exists() {
+            return Err(eyre!("Docker tarball not found: {}", path.display()))
+                .with_section(|| path.display().to_string().header("Path:"));
+        }
+
+        let manifest = read_docker_manifest(&path).await?;
+        let image_digest = compute_image_digest(&path, &manifest).await?;
+        let name = infer_name(&manifest, &image_digest);
+        let layers = parse_layers(&path, &manifest).await?;
+
+        Ok(Self {
+            path,
+            manifest,
+            image_digest,
+            name,
+            layers,
+            layer_filters: layer_filters.unwrap_or_default(),
+            file_filters: file_filters.unwrap_or_default(),
+        })
+    }
+}
+
+impl Tarball {
+    /// Report the digest for the image.
+    #[tracing::instrument]
+    pub async fn digest(&self) -> Result<Digest> {
+        Ok(self.image_digest.clone())
+    }
+
+    /// Report the name of the image.
+    #[tracing::instrument]
+    pub async fn name(&self) -> Result<String> {
+        Ok(self.name.clone())
+    }
+
+    /// Enumerate layers for a container image.
+    /// Layers are returned in order from the base image to the application.
+    #[tracing::instrument]
+    pub async fn layers(&self) -> Result<Vec<Layer>> {
+        // Filter layers if filters are set
+        let filtered = self
+            .layers
+            .iter()
+            .filter(|&layer| self.layer_filters.matches(layer))
+            .cloned()
+            .collect();
+
+        Ok(filtered)
+    }
+
+    /// Pull the bytes of a layer from the tarball in a stream.
+    #[tracing::instrument]
+    pub async fn pull_layer(
+        &self,
+        layer: &Layer,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>> {
+        // Find the layer index within our manifests
+        let layer_index = self.find_layer_index(layer)?;
+        let layer_path = Path::new(&self.manifest.layers[layer_index]);
+
+        // Create a temporary reader for the tarball
+        let reader = create_layer_reader(&self.path, layer_path).await?;
+
+        // Map std::io::Error to color_eyre::Report
+        let stream = reader.map(|result| result.map_err(|e| eyre!("Error reading layer: {e}")));
+
+        // Return a stream of bytes
+        Ok(Box::pin(stream))
+    }
+
+    /// Enumerate files in a layer.
+    #[tracing::instrument]
+    pub async fn list_files(&self, layer: &Layer) -> Result<Vec<String>> {
+        let stream = self.pull_layer_internal(layer).await?;
+
+        match &layer.media_type {
+            LayerMediaType::Oci(flags) => {
+                match flags.as_slice() {
+                    // No flags; this means the layer is uncompressed
+                    [] => enumerate_tarball(stream).await,
+
+                    // The layer is compressed with gzip
+                    [LayerMediaTypeFlag::Gzip] => {
+                        let stream = transform::gzip(stream);
+                        enumerate_tarball(stream).await
+                    }
+
+                    // The layer is compressed with zstd
+                    [LayerMediaTypeFlag::Zstd] => {
+                        let stream = transform::zstd(stream);
+                        enumerate_tarball(stream).await
+                    }
+
+                    // More complex transformation sequence
+                    _ => {
+                        let stream = transform::sequence(stream, flags);
+                        enumerate_tarball(stream).await
+                    }
+                }
+            }
+        }
+    }
+
+    /// Apply a layer to a location on disk.
+    ///
+    /// The intention of this method is that when it is run for each layer in an image in order it is equivalent
+    /// to the functionality you'd get by running `docker pull`, `docker save`, and then recursively extracting the
+    /// layers to the same directory.
+    #[tracing::instrument]
+    pub async fn apply_layer(&self, layer: &Layer, output: &Path) -> Result<()> {
+        let stream = self.pull_layer_internal(layer).await?;
+
+        match &layer.media_type {
+            LayerMediaType::Oci(flags) => {
+                // Skip foreign layers
+                if flags.contains(&LayerMediaTypeFlag::Foreign) {
+                    warn!("skip: foreign layer");
+                    return Ok(());
+                }
+
+                match flags.as_slice() {
+                    // No flags; this means the layer is uncompressed
+                    [] => apply_tarball(&self.file_filters, stream, output).await,
+
+                    // The layer is compressed with gzip
+                    [LayerMediaTypeFlag::Gzip] => {
+                        let stream = transform::gzip(stream);
+                        apply_tarball(&self.file_filters, stream, output).await
+                    }
+
+                    // The layer is compressed with zstd
+                    [LayerMediaTypeFlag::Zstd] => {
+                        let stream = transform::zstd(stream);
+                        apply_tarball(&self.file_filters, stream, output).await
+                    }
+
+                    // More complex transformation sequence
+                    _ => {
+                        let stream = transform::sequence(stream, flags);
+                        apply_tarball(&self.file_filters, stream, output).await
+                    }
+                }
+            }
+        }
+    }
+
+    /// Normalize an OCI layer into a plain tarball layer.
+    #[tracing::instrument]
+    pub async fn layer_plain_tarball(&self, layer: &Layer) -> Result<Option<TempFile>> {
+        let stream = self.pull_layer_internal(layer).await?;
+
+        match &layer.media_type {
+            LayerMediaType::Oci(flags) => {
+                // Skip foreign layers
+                if flags.contains(&LayerMediaTypeFlag::Foreign) {
+                    warn!("skip: foreign layer");
+                    return Ok(None);
+                }
+
+                Ok(Some(match flags.as_slice() {
+                    // No flags; this means the layer is already uncompressed
+                    [] => collect_tmp(stream).await?,
+
+                    // The layer is compressed with gzip
+                    [LayerMediaTypeFlag::Gzip] => transform::gzip(stream).pipe(collect_tmp).await?,
+
+                    // The layer is compressed with zstd
+                    [LayerMediaTypeFlag::Zstd] => transform::zstd(stream).pipe(collect_tmp).await?,
+
+                    // More complex transformation sequence
+                    _ => transform::sequence(stream, flags).pipe(collect_tmp).await?,
+                }))
+            }
+        }
+    }
+
+    /// Find the layer index in the manifest that corresponds to this layer
+    fn find_layer_index(&self, layer: &Layer) -> Result<usize> {
+        self.layers
+            .iter()
+            .position(|l| l.digest == layer.digest)
+            .ok_or_else(|| eyre!("Layer not found in tarball: {}", layer.digest))
+    }
+
+    /// Internal helper for pulling layer data
+    async fn pull_layer_internal(&self, layer: &Layer) -> Result<impl Stream<Item = Chunk>> {
+        // Find the layer index within our manifests
+        let layer_index = self.find_layer_index(layer)?;
+        let layer_path = Path::new(&self.manifest.layers[layer_index]);
+
+        // Create a reader for the layer
+        create_layer_reader(&self.path, layer_path).await
+    }
+}
+
+/// Read manifest from a Docker tarball
+async fn read_docker_manifest(tarball_path: &Path) -> Result<DockerManifest> {
+    debug!(
+        "Reading manifest from Docker tarball: {}",
+        tarball_path.display()
+    );
+
+    let file = tokio::fs::File::open(tarball_path).await.context(format!(
+        "opening docker tarball: {}",
+        tarball_path.display()
+    ))?;
+
+    let mut archive = Archive::new(file);
+    let mut manifest_entry = None;
+
+    let mut entries = archive.entries().context(format!(
+        "reading entries from tarball: {}",
+        tarball_path.display()
+    ))?;
+
+    while let Some(entry_result) = entries.next().await {
+        let entry = entry_result.context("reading tarball entry")?;
+        let path = entry.path().context("reading entry path")?;
+        let path = path.to_string_lossy();
+
+        if path == "manifest.json" || path.ends_with("/manifest.json") {
+            debug!("Found manifest at path: {path}");
+            manifest_entry = Some(entry);
+            break;
+        }
+    }
+
+    let mut manifest_entry = manifest_entry.ok_or_else(|| {
+        eyre!("manifest.json not found in Docker tarball")
+            .with_section(|| tarball_path.display().to_string().header("Tarball path:"))
+    })?;
+
+    let mut manifest_contents = String::new();
+    manifest_entry
+        .read_to_string(&mut manifest_contents)
+        .await
+        .context("reading manifest.json contents")?;
+
+    debug!("Parsing manifest.json content");
+
+    // Try first as an array (standard format), then as a single object
+    let array_result: Result<Vec<DockerManifest>, _> = serde_json::from_str(&manifest_contents);
+
+    match array_result {
+        Ok(mut manifests) => {
+            if manifests.is_empty() {
+                return Err(eyre!("Docker tarball contains empty manifest.json array"))
+                    .with_section(|| tarball_path.display().to_string().header("Tarball path:"));
+            }
+
+            debug!(
+                "Successfully parsed manifest.json as array with {} entries",
+                manifests.len()
+            );
+            Ok(manifests.remove(0))
+        }
+
+        Err(_) => {
+            debug!("Manifest is not an array, trying to parse as single object");
+            let single_result: Result<DockerManifest, _> = serde_json::from_str(&manifest_contents);
+
+            match single_result {
+                Ok(manifest) => {
+                    debug!("Successfully parsed manifest.json as single object");
+                    Ok(manifest)
+                }
+                Err(err) => {
+                    // Both parsing attempts failed, return the original error
+                    Err(eyre!("Failed to parse manifest.json: {err}"))
+                        .with_section(|| tarball_path.display().to_string().header("Tarball path:"))
+                        .with_section(|| manifest_contents.to_string().header("Manifest content:"))
+                }
+            }
+        }
+    }
+}
+
+/// Compute the image digest from the config file
+async fn compute_image_digest(tarball_path: &Path, manifest: &DockerManifest) -> Result<Digest> {
+    let file = tokio::fs::File::open(tarball_path)
+        .await
+        .context("opening docker tarball")?;
+
+    let mut archive = Archive::new(file);
+    let mut config_entry = None;
+
+    let config_path = &manifest.config;
+    let mut entries = archive.entries().context("reading tarball entries")?;
+    while let Some(entry_result) = entries.next().await {
+        let entry = entry_result.context("read tarball entry")?;
+        let path = entry.path().context("read entry path")?;
+
+        if path.to_string_lossy() == config_path.as_str() {
+            config_entry = Some(entry);
+            break;
+        }
+    }
+
+    let mut config_entry = config_entry
+        .ok_or_else(|| eyre!("config file not found in Docker tarball: {}", config_path))?;
+
+    let mut config_data = Vec::new();
+    config_entry
+        .read_to_end(&mut config_data)
+        .await
+        .context("reading config file contents")?;
+
+    let mut hasher = sha2::Sha256::new();
+    use sha2::Digest as Sha256Digest;
+    hasher.update(&config_data);
+    let hash = hasher.finalize();
+
+    Ok(crate::Digest {
+        algorithm: crate::Digest::SHA256.to_string(),
+        hash: hash.to_vec(),
+    })
+}
+
+/// Infer the image name from the manifest
+fn infer_name(manifest: &DockerManifest, digest: &Digest) -> String {
+    // Try to get name from repo tags
+    if let Some(tag) = manifest.repo_tags.first() {
+        // Return the tag without the version part
+        if let Some(colon_pos) = tag.rfind(':') {
+            return tag[..colon_pos].to_string();
+        }
+        return tag.clone();
+    }
+
+    // Fallback to using digest
+    format!("image@{digest}")
+}
+
+/// Parse the layers from the manifest
+async fn parse_layers(tarball_path: &Path, manifest: &DockerManifest) -> Result<Vec<Layer>> {
+    let mut layers = Vec::new();
+
+    for layer_file in &manifest.layers {
+        let layer_size = get_layer_size(tarball_path, layer_file).await?;
+        let digest = extract_digest_from_layer_path(layer_file)?;
+        let media_type = detect_layer_media_type(tarball_path, layer_file).await?;
+
+        layers.push(Layer {
+            digest,
+            size: layer_size as i64,
+            media_type,
+        });
+    }
+
+    Ok(layers)
+}
+
+/// Detect the media type of a layer by examining its content
+async fn detect_layer_media_type(tarball_path: &Path, layer_file: &str) -> Result<LayerMediaType> {
+    // Most Docker tarballs use gzip compression by default
+    let default_type = LayerMediaType::Oci(vec![LayerMediaTypeFlag::Gzip]);
+
+    let file = match tokio::fs::File::open(tarball_path).await {
+        Ok(f) => f,
+        Err(_) => return Ok(default_type), // Return default on error
+    };
+
+    let mut archive = Archive::new(file);
+    let mut layer_entry = None;
+
+    let mut entries = match archive.entries() {
+        Ok(e) => e,
+        Err(_) => return Ok(default_type),
+    };
+
+    while let Some(entry_result) = entries.next().await {
+        match entry_result {
+            Ok(entry) => {
+                if let Ok(path) = entry.path() {
+                    if path.to_string_lossy() == layer_file {
+                        layer_entry = Some(entry);
+                        break;
+                    }
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    let mut layer_entry = match layer_entry {
+        Some(entry) => entry,
+        None => return Ok(default_type),
+    };
+
+    // Read the first few bytes to determine compression format
+    let mut buffer = [0u8; 8];
+    match layer_entry.read_exact(&mut buffer).await {
+        Ok(_) => {
+            // Check for gzip magic bytes (1F 8B)
+            if buffer[0] == 0x1F && buffer[1] == 0x8B {
+                return Ok(LayerMediaType::Oci(vec![LayerMediaTypeFlag::Gzip]));
+            }
+
+            // Check for zstd magic bytes (28 B5 2F FD)
+            if buffer[0] == 0x28 && buffer[1] == 0xB5 && buffer[2] == 0x2F && buffer[3] == 0xFD {
+                return Ok(LayerMediaType::Oci(vec![LayerMediaTypeFlag::Zstd]));
+            }
+
+            // If no compression detected, it's a raw tarball
+            Ok(LayerMediaType::Oci(vec![]))
+        }
+        Err(_) => Ok(default_type),
+    }
+}
+
+/// Extract the digest from a layer path in the Docker tarball
+fn extract_digest_from_layer_path(layer_path: &str) -> Result<Digest> {
+    // Docker layer paths can be in different formats:
+    // 1. "<hash>/layer.tar" (most common in docker save output)
+    // 2. "layers/<hash>/layer.tar" (also seen in some docker save outputs)
+    // 3. "<hash>.tar" (rare but possible)
+
+    // First, try to extract hash from the parent directory name
+    if let Some(parent) = Path::new(layer_path).parent() {
+        if let Some(filename) = parent.file_name() {
+            if let Some(hash_str) = filename.to_str() {
+                // Validate that it looks like a SHA256 hash (64 hex characters)
+                if hash_str.len() == 64 && hash_str.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return Ok(Digest {
+                        algorithm: Digest::SHA256.to_string(),
+                        hash: hex::decode(hash_str)
+                            .context(format!("Invalid hex in digest: {hash_str}"))?,
+                    });
+                }
+            }
+        }
+    }
+
+    // Alternative: try to extract from the filename itself (for <hash>.tar format)
+    if let Some(filename) = Path::new(layer_path).file_stem() {
+        if let Some(hash_str) = filename.to_str() {
+            // Validate that it looks like a SHA256 hash (64 hex characters)
+            if hash_str.len() == 64 && hash_str.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Ok(Digest {
+                    algorithm: Digest::SHA256.to_string(),
+                    hash: hex::decode(hash_str)
+                        .context(format!("Invalid hex in digest: {hash_str}"))?,
+                });
+            }
+        }
+    }
+
+    // If we can't determine a hash from the path, generate one from the content
+    // This is a fallback that should rarely be needed with standard Docker tarballs
+    Err(eyre!("Cannot extract hash from layer path: {layer_path}\nThis doesn't appear to be a standard Docker layer path format."))
+}
+
+/// Get the size of a layer tarball within the docker tarball
+async fn get_layer_size(tarball_path: &Path, layer_file: &str) -> Result<u64> {
+    let file = tokio::fs::File::open(tarball_path)
+        .await
+        .context("opening docker tarball")?;
+
+    let mut archive = Archive::new(file);
+
+    // Find the layer file entry
+    let mut entries = archive.entries().context("reading tarball entries")?;
+    while let Some(entry_result) = entries.next().await {
+        let entry = entry_result.context("reading tarball entry")?;
+        let path = entry.path().context("reading entry path")?;
+
+        if path.to_string_lossy() == layer_file {
+            return Ok(entry.header().size().unwrap_or(0));
+        }
+    }
+
+    Err(eyre!("Layer file not found in tarball: {layer_file}"))
+}
+
+/// Create a reader for a specific layer in the docker tarball
+///
+/// This is a bit inefficient as it needs to scan the tarball for each layer access,
+/// but it's more memory-efficient than loading the whole tarball at once.
+async fn create_layer_reader(
+    tarball_path: &Path,
+    layer_path: &Path,
+) -> Result<impl Stream<Item = Chunk>> {
+    debug!(
+        "Opening layer {} from Docker tarball {}",
+        layer_path.display(),
+        tarball_path.display()
+    );
+
+    if !tarball_path.exists() {
+        return Err(eyre!(
+            "Docker tarball not found: {}",
+            tarball_path.display()
+        ))
+        .with_section(|| tarball_path.display().to_string().header("Tarball path:"));
+    }
+
+    let file = tokio::fs::File::open(tarball_path).await.context(format!(
+        "opening docker tarball: {}",
+        tarball_path.display()
+    ))?;
+
+    let mut archive = Archive::new(file);
+    let mut layer_entry = None;
+
+    let layer_path = layer_path.to_string_lossy();
+    debug!("Searching for layer: {layer_path}");
+
+    let mut entries = archive.entries().context(format!(
+        "reading entries from tarball: {}",
+        tarball_path.display()
+    ))?;
+
+    while let Some(entry_result) = entries.next().await {
+        let entry = entry_result.context("reading tarball entry")?;
+        let path = entry.path().context("reading entry path")?;
+        let path = path.to_string_lossy();
+
+        if path == layer_path {
+            debug!("Found exact match for layer: {layer_path}");
+            layer_entry = Some(entry);
+            break;
+        }
+
+        // Sometimes Docker tarballs can have inconsistent path separators or extra components
+        // Try normalizing paths for comparison
+        let normalized_entry = Path::new(&*path)
+            .file_name()
+            .map(|f| f.to_string_lossy());
+
+        let normalized_layer = Path::new(&*layer_path)
+            .file_name()
+            .map(|f| f.to_string_lossy());
+
+        if let (Some(ne), Some(nl)) = (normalized_entry, normalized_layer) {
+            if ne == nl {
+                debug!("Found normalized match for layer: {layer_path} as {path}");
+                layer_entry = Some(entry);
+                break;
+            }
+        }
+    }
+
+    if layer_entry.is_none() {
+        debug!("Layer not found with exact match, trying flexible search: {layer_path}");
+
+        let file = tokio::fs::File::open(tarball_path).await.context(format!(
+            "reopening docker tarball: {}",
+            tarball_path.display()
+        ))?;
+
+        let mut archive = Archive::new(file);
+        let mut entries = archive.entries().context(format!(
+            "reading entries from tarball (second pass): {}",
+            tarball_path.display()
+        ))?;
+
+        let target_filename = Path::new(&*layer_path)
+            .file_name()
+            .map(|f| f.to_string_lossy().to_string())
+            .unwrap_or_else(|| "layer.tar".to_string());
+
+        while let Some(entry_result) = entries.next().await {
+            let entry = entry_result.context("reading tarball entry")?;
+            let path = entry.path().context("reading entry path")?;
+
+            if path.to_string_lossy().ends_with(&target_filename) {
+                debug!(
+                    "Found partial match for layer: {layer_path} as {}",
+                    path.to_string_lossy()
+                );
+                layer_entry = Some(entry);
+                break;
+            }
+        }
+    }
+
+    let layer_entry = layer_entry.ok_or_else(|| {
+        eyre!(
+            "Layer {} not found in Docker tarball {}",
+            layer_path,
+            tarball_path.display()
+        )
+        .with_section(|| layer_path.to_string().header("Layer path:"))
+        .with_section(|| tarball_path.display().to_string().header("Tarball path:"))
+    })?;
+
+    debug!("Successfully found and opened layer: {layer_path}");
+    Ok(ReaderStream::new(layer_entry))
+}
+
+impl Source for Tarball {
+    async fn digest(&self) -> Result<Digest> {
+        self.digest().await
+    }
+
+    async fn name(&self) -> Result<String> {
+        self.name().await
     }
 
     async fn layers(&self) -> Result<Vec<Layer>> {

--- a/lib/src/docker.rs
+++ b/lib/src/docker.rs
@@ -663,7 +663,7 @@ mod tests {
     use crate::{digest, Layer, LayerMediaType};
 
     #[test]
-    fn parse_docker_manifest_nignx() {
+    fn parse_docker_manifest_nginx() {
         let content = include_str!("./testdata/nginx_manifest.json");
 
         let expected = DockerManifest {

--- a/lib/src/docker.rs
+++ b/lib/src/docker.rs
@@ -248,7 +248,7 @@ impl Daemon {
         #[builder(into)]
         reference: String,
     ) -> Result<Self> {
-        debug!("exporting image");
+        crate::flag_disabled_daemon_docker()?;
 
         let docker = Docker::connect_with_local_defaults().context("connect to docker daemon")?;
         let image = find_image(&docker, &reference)

--- a/lib/src/docker.rs
+++ b/lib/src/docker.rs
@@ -10,9 +10,9 @@ use crate::{
         self, apply_tarball, collect_json, collect_tmp, enumerate_tarball, extract_file,
         extract_json, file_digest, peel_layer,
     },
-    homedir,
+    digest, homedir,
     transform::Chunk,
-    Authentication, Digest, FilterMatch, Filters, Layer, Reference, Source,
+    Authentication, Digest, FilterMatch, Filters, Layer, LayerMediaType, Reference, Source,
 };
 use async_tempfile::TempFile;
 use base64::Engine;
@@ -405,7 +405,7 @@ impl Tarball {
 }
 
 /// A Docker OCI manifest.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DockerManifest {
     /// The layers in the manifest.
@@ -654,4 +654,72 @@ async fn digest(tarball: &Path) -> Result<Digest> {
     }
 
     file_digest(tarball).await
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn parse_docker_manifest_nignx() {
+        let content = include_str!("./testdata/nginx_manifest.json");
+
+        let expected = DockerManifest {
+            layers: vec![
+                Layer {
+                    digest: digest!(
+                        "5f1ee22ffb5e68686db3dcb6584eb1c73b5570615b0f14fabb070b96117e351d"
+                    ),
+                    size: 77844480,
+                    media_type: LayerMediaType::default(),
+                },
+                Layer {
+                    digest: digest!(
+                        "c68632c455ae0c46d1380033bae6d30014853fa3f600f4e14efc440be1bc9580"
+                    ),
+                    size: 118268416,
+                    media_type: LayerMediaType::default(),
+                },
+                Layer {
+                    digest: digest!(
+                        "cabea05c000e49f0814b2611cbc66c2787f609d8a27fc7b9e97b5dab5d8502da"
+                    ),
+                    size: 3584,
+                    media_type: LayerMediaType::default(),
+                },
+                Layer {
+                    digest: digest!(
+                        "791f0a07985c2814a899cb0458802be06ba124a364f7e5a9413a1f08fdbf5b5c"
+                    ),
+                    size: 4608,
+                    media_type: LayerMediaType::default(),
+                },
+                Layer {
+                    digest: digest!(
+                        "f6d5815f290ee912fd4a768d97b46af39523dff584d786f5c0f7e9bdb7fad537"
+                    ),
+                    size: 2560,
+                    media_type: LayerMediaType::default(),
+                },
+                Layer {
+                    digest: digest!(
+                        "7d22e2347c1217a89bd3c79ca9adb4652c1e9b61427fffc0ab92227aacd19a38"
+                    ),
+                    size: 5120,
+                    media_type: LayerMediaType::default(),
+                },
+                Layer {
+                    digest: digest!(
+                        "55e9644f21c38d7707b4a432aacc7817c5414b68ac7a750e704c2f7100ebc15c"
+                    ),
+                    size: 7168,
+                    media_type: LayerMediaType::default(),
+                },
+            ],
+        };
+
+        let manifest = serde_json::from_str(content).expect("parse manifest");
+        pretty_assertions::assert_eq!(expected, manifest);
+    }
 }

--- a/lib/src/docker.rs
+++ b/lib/src/docker.rs
@@ -10,9 +10,9 @@ use crate::{
         self, apply_tarball, collect_json, collect_tmp, enumerate_tarball, extract_file,
         extract_json, file_digest, peel_layer,
     },
-    digest, homedir,
+    homedir,
     transform::Chunk,
-    Authentication, Digest, FilterMatch, Filters, Layer, LayerMediaType, Reference, Source,
+    Authentication, Digest, FilterMatch, Filters, Layer, Reference, Source,
 };
 use async_tempfile::TempFile;
 use base64::Engine;
@@ -660,6 +660,7 @@ async fn digest(tarball: &Path) -> Result<Digest> {
 mod tests {
 
     use super::*;
+    use crate::{digest, Layer, LayerMediaType};
 
     #[test]
     fn parse_docker_manifest_nignx() {

--- a/lib/src/extract.rs
+++ b/lib/src/extract.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::{Digest, Layer, Reference, Source};
+use crate::{Digest, Layer, Source};
 use bon::Builder;
 use color_eyre::{
     eyre::{bail, Context, Error},
@@ -15,14 +15,6 @@ use tracing::info;
 /// Report containing details about the extracted container image.
 #[derive(Debug, Serialize, Builder)]
 pub struct Report {
-    /// The original reference requested when extracting the image.
-    #[builder(into)]
-    pub reference: Reference,
-
-    /// The repository name of the image.
-    #[builder(into)]
-    pub name: String,
-
     /// The content-addressable digest of the image.
     #[builder(into)]
     pub digest: String,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -36,6 +36,52 @@ pub mod fossacli;
 pub mod registry;
 pub mod transform;
 
+/// Users can set this environment variable to specify the OCI base.
+/// If not set, the default is [`OCI_DEFAULT_BASE`].
+pub const OCI_BASE_VAR: &str = "OCI_DEFAULT_BASE";
+
+/// Users can set this environment variable to specify the OCI namespace.
+/// If not set, the default is [`OCI_DEFAULT_NAMESPACE`].
+pub const OCI_NAMESPACE_VAR: &str = "OCI_DEFAULT_NAMESPACE";
+
+/// The default OCI base.
+pub const OCI_DEFAULT_BASE: &str = "docker.io";
+
+/// The default OCI namespace.
+pub const OCI_DEFAULT_NAMESPACE: &str = "library";
+
+/// Set to any value to disable OCI registry connection.
+pub const OCI_DISABLE_REGISTRY_OCI_VAR: &str = "CIRCE_DISABLE_REGISTRY_OCI";
+
+/// Set to any value to disable docker daemon connection.
+pub const OCI_DISABLE_DAEMON_DOCKER_VAR: &str = "CIRCE_DISABLE_DAEMON_DOCKER";
+
+/// The OCI base.
+pub fn oci_base() -> String {
+    std::env::var(OCI_BASE_VAR).unwrap_or(OCI_DEFAULT_BASE.to_string())
+}
+
+/// The OCI namespace.
+pub fn oci_namespace() -> String {
+    std::env::var(OCI_NAMESPACE_VAR).unwrap_or(OCI_DEFAULT_NAMESPACE.to_string())
+}
+
+/// Whether OCI registry connection is disabled.
+pub fn flag_disabled_registry_oci() -> Result<()> {
+    if std::env::var(OCI_DISABLE_REGISTRY_OCI_VAR).is_ok() {
+        bail!("{OCI_DISABLE_REGISTRY_OCI_VAR} is set, skipping OCI registry connection");
+    }
+    Ok(())
+}
+
+/// Whether docker daemon connection is disabled.
+pub fn flag_disabled_daemon_docker() -> Result<()> {
+    if std::env::var(OCI_DISABLE_DAEMON_DOCKER_VAR).is_ok() {
+        bail!("{OCI_DISABLE_DAEMON_DOCKER_VAR} is set, skipping docker daemon connection");
+    }
+    Ok(())
+}
+
 /// A trait that abstracts interaction with container images.
 ///
 /// This trait provides methods to interact with container images,
@@ -77,30 +123,6 @@ pub trait Source: std::fmt::Debug {
     /// The twist though is that OCI servers can wrap various kinds of compression around tarballs;
     /// this method flattens them all down into plain uncompressed `.tar` files.
     fn layer_plain_tarball(&self, layer: &Layer) -> impl Future<Output = Result<Option<TempFile>>>;
-}
-
-/// Users can set this environment variable to specify the OCI base.
-/// If not set, the default is [`OCI_DEFAULT_BASE`].
-pub const OCI_BASE_VAR: &str = "OCI_DEFAULT_BASE";
-
-/// Users can set this environment variable to specify the OCI namespace.
-/// If not set, the default is [`OCI_DEFAULT_NAMESPACE`].
-pub const OCI_NAMESPACE_VAR: &str = "OCI_DEFAULT_NAMESPACE";
-
-/// The default OCI base.
-pub const OCI_DEFAULT_BASE: &str = "docker.io";
-
-/// The default OCI namespace.
-pub const OCI_DEFAULT_NAMESPACE: &str = "library";
-
-/// The OCI base.
-pub fn oci_base() -> String {
-    std::env::var(OCI_BASE_VAR).unwrap_or(OCI_DEFAULT_BASE.to_string())
-}
-
-/// The OCI namespace.
-pub fn oci_namespace() -> String {
-    std::env::var(OCI_NAMESPACE_VAR).unwrap_or(OCI_DEFAULT_NAMESPACE.to_string())
 }
 
 /// Authentication method for a registry.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -362,16 +362,16 @@ impl From<&Platform> for Platform {
 #[macro_export]
 macro_rules! digest {
     ($hex:expr) => {{
-        circe_lib::digest!(circe_lib::Digest::SHA256, $hex, 32)
+        $crate::digest!($crate::Digest::SHA256, $hex, 32)
     }};
     ($algorithm:expr, $hex:expr) => {{
-        circe_lib::digest!($algorithm, $hex, 32)
+        $crate::digest!($algorithm, $hex, 32)
     }};
     ($algorithm:expr, $hex:expr, $size:expr) => {{
         const HASH: [u8; $size] = hex_magic::hex!($hex);
         static_assertions::const_assert_ne!(HASH.len(), 0);
         static_assertions::const_assert_ne!($algorithm.len(), 0);
-        circe_lib::Digest {
+        $crate::Digest {
             algorithm: $algorithm.to_string(),
             hash: HASH.to_vec(),
         }
@@ -823,6 +823,12 @@ impl LayerMediaType {
     }
 }
 
+impl Default for LayerMediaType {
+    fn default() -> Self {
+        Self::Oci(Vec::new())
+    }
+}
+
 impl FromStr for LayerMediaType {
     type Err = eyre::Error;
 
@@ -911,6 +917,11 @@ pub enum LayerMediaTypeFlag {
 impl LayerMediaTypeFlag {
     /// Parse a string into a set of flags, separated by `+` characters.
     fn parse_set(s: &str) -> Result<Vec<Self>> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Ok(Vec::new());
+        }
+
         s.split('+').map(Self::from_str).try_collect()
     }
 }
@@ -921,7 +932,7 @@ impl FromStr for LayerMediaTypeFlag {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::iter()
             .find(|flag| flag.as_ref() == s)
-            .ok_or_else(|| eyre!("unknown flag: {s}"))
+            .ok_or_else(|| eyre!("unknown flag: '{s}'"))
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,7 @@
-//! Core library for `circe`, a tool for extracting OCI images.
+#![deny(clippy::uninlined_format_args)]
+#![deny(clippy::unwrap_used)]
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
 
 use async_tempfile::TempFile;
 use bon::Builder;
@@ -638,8 +641,8 @@ impl std::fmt::Display for Reference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}/{}", self.host, self.namespace, self.name)?;
         match &self.version {
-            Version::Tag(tag) => write!(f, ":{}", tag),
-            Version::Digest(digest) => write!(f, "@{}", digest),
+            Version::Tag(tag) => write!(f, ":{tag}"),
+            Version::Digest(digest) => write!(f, "@{digest}"),
         }
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -305,6 +305,12 @@ impl std::fmt::Display for Platform {
     }
 }
 
+impl From<&Platform> for Platform {
+    fn from(platform: &Platform) -> Self {
+        platform.clone()
+    }
+}
+
 /// Create a [`Digest`] from a hex string at compile time.
 /// ```
 /// let digest = circe_lib::digest!("sha256", "a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4");

--- a/lib/src/registry.rs
+++ b/lib/src/registry.rs
@@ -63,6 +63,7 @@ impl Registry {
         auth: Option<Authentication>,
 
         /// The platform to use for the registry.
+        #[builder(into)]
         platform: Option<Platform>,
 
         /// Filters for layers.

--- a/lib/src/registry.rs
+++ b/lib/src/registry.rs
@@ -43,11 +43,11 @@ pub struct Registry {
     auth: RegistryAuth,
 
     /// Layer filters.
-    /// Layers that match any filter are included in the set of layers processed by this registry.
+    /// Layers that match any filter are excluded from the set of layers processed by this registry.
     layer_filters: Filters,
 
     /// File filters.
-    /// Files that match any filter are included in the set of files processed by this registry.
+    /// Files that match any filter are excluded from the set of files processed by this registry.
     file_filters: Filters,
 
     /// The client used to interact with the registry.
@@ -67,11 +67,11 @@ impl Registry {
         platform: Option<Platform>,
 
         /// Filters for layers.
-        /// Layers that match any filter are included in the set of layers processed by this registry.
+        /// Layers that match any filter are excluded from the set of layers processed by this registry.
         layer_filters: Option<Filters>,
 
         /// Filters for files.
-        /// Files that match any filter are included in the set of files processed by this registry.
+        /// Files that match any filter are excluded from the set of files processed by this registry.
         file_filters: Option<Filters>,
 
         /// The reference to use for the registry.

--- a/lib/src/registry.rs
+++ b/lib/src/registry.rs
@@ -462,12 +462,13 @@ impl FilterMatch<&PathBuf> for Filter {
 }
 
 fn client(platform: Option<Platform>) -> Client {
-    let mut config = ClientConfig::default();
-    config.platform_resolver = match platform {
-        Some(platform) => Some(Box::new(target_platform_resolver(platform))),
-        None => Some(Box::new(current_platform_resolver)),
-    };
-    Client::new(config)
+    Client::new(ClientConfig {
+        platform_resolver: match platform {
+            Some(platform) => Some(Box::new(target_platform_resolver(platform))),
+            None => Some(Box::new(current_platform_resolver)),
+        },
+        ..Default::default()
+    })
 }
 
 fn target_platform_resolver(target: Platform) -> impl Fn(&[ImageIndexEntry]) -> Option<String> {
@@ -475,7 +476,7 @@ fn target_platform_resolver(target: Platform) -> impl Fn(&[ImageIndexEntry]) -> 
         entries
             .iter()
             .find(|entry| {
-                entry.platform.as_ref().map_or(false, |platform| {
+                entry.platform.as_ref().is_some_and(|platform| {
                     platform.os == target.os && platform.architecture == target.architecture
                 })
             })

--- a/lib/src/registry.rs
+++ b/lib/src/registry.rs
@@ -2,12 +2,13 @@
 
 use std::{
     path::{Path, PathBuf},
+    pin::Pin,
     str::FromStr,
 };
 
 use async_tempfile::TempFile;
 use bytes::Bytes;
-use color_eyre::eyre::{Context, OptionExt, Result};
+use color_eyre::eyre::{Context, Result};
 use derive_more::Debug;
 use futures_lite::{Stream, StreamExt};
 use oci_client::{
@@ -16,35 +17,16 @@ use oci_client::{
     secrets::RegistryAuth,
     Client, Reference as OciReference, RegistryOperation,
 };
-use os_str_bytes::OsStrBytesExt;
 use tap::Pipe;
-use tokio::io::{AsyncRead, AsyncWriteExt, BufWriter};
-use tokio_tar::{Archive, Entry};
-use tokio_util::io::StreamReader;
 use tracing::{debug, warn};
 
 use crate::{
+    cfs::{apply_tarball, collect_tmp, enumerate_tarball},
     ext::PriorityFind,
     transform::{self, Chunk},
     Authentication, Digest, Filter, FilterMatch, Filters, Layer, LayerMediaType,
     LayerMediaTypeFlag, Platform, Reference, Source, Version,
 };
-
-/// Unwrap a value, logging an error and performing the provided action if it fails.
-macro_rules! unwrap_warn {
-    ($expr:expr, $action:expr) => {
-        unwrap_warn!($expr, $action,)
-    };
-    ($expr:expr, $action:expr, $($msg:tt)*) => {
-        match $expr {
-            Ok(value) => value,
-            Err(e) => {
-                tracing::warn!(error = ?e, $($msg)*);
-                $action;
-            }
-        }
-    };
-}
 
 /// Each instance is a unique view of remote registry for a specific [`Platform`] and [`Reference`].
 /// The intention here is to better support chained methods like "pull list of layers" and then "apply each layer to disk".
@@ -163,10 +145,13 @@ impl Registry {
     /// - A file is added.
     /// - A file is removed.
     /// - A file is modified.
-    pub async fn pull_layer(&self, layer: &Layer) -> Result<impl Stream<Item = Result<Bytes>>> {
+    pub async fn pull_layer(
+        &self,
+        layer: &Layer,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>> {
         self.pull_layer_internal(layer)
             .await
-            .map(|stream| stream.map(|chunk| chunk.context("read chunk")))
+            .map(|stream| stream.map(|chunk| chunk.context("read chunk")).boxed())
     }
 
     async fn pull_layer_internal(&self, layer: &Layer) -> Result<impl Stream<Item = Chunk>> {
@@ -373,19 +358,22 @@ impl Registry {
 }
 
 impl Source for Registry {
-    fn original(&self) -> &Reference {
-        &self.original
+    async fn digest(&self) -> Result<Digest> {
+        self.digest().await
+    }
+
+    async fn name(&self) -> Result<String> {
+        Ok(self.original.name.clone())
     }
 
     async fn layers(&self) -> Result<Vec<Layer>> {
         self.layers().await
     }
 
-    async fn digest(&self) -> Result<Digest> {
-        self.digest().await
-    }
-
-    async fn pull_layer(&self, layer: &Layer) -> Result<impl Stream<Item = Result<Bytes>>> {
+    async fn pull_layer(
+        &self,
+        layer: &Layer,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>> {
         self.pull_layer(layer).await
     }
 
@@ -402,236 +390,15 @@ impl Source for Registry {
     }
 }
 
-/// Sink the stream into a temporary file.
-async fn collect_tmp(mut stream: impl Stream<Item = Chunk> + Unpin) -> Result<TempFile> {
-    let file = TempFile::new().await.context("create temp file")?;
-    let mut writer = BufWriter::new(file);
-
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.context("read chunk")?;
-        writer.write_all(&chunk).await.context("write chunk")?;
-    }
-    writer.flush().await.context("flush writer")?;
-
-    let file = writer.into_inner();
-    file.sync_all().await.context("sync file")?;
-    Ok(file)
-}
-
-/// Apply files in the tarball to a location on disk.
-async fn apply_tarball(
-    path_filters: &Filters,
-    stream: impl Stream<Item = Chunk> + Unpin,
-    output: &Path,
-) -> Result<()> {
-    let reader = StreamReader::new(stream);
-    let mut archive = Archive::new(reader);
-    let mut entries = archive.entries().context("read entries from tar")?;
-
-    // Future improvement: the OCI spec guarantees that paths will not repeat within the same layer,
-    // so we could concurrently read files and apply them to disk.
-    // The overall archive is streaming so we'd need to buffer the entries,
-    // but assuming disk is the bottleneck this might speed up the process significantly.
-    // We could also of course write the tar to disk and then extract it concurrently
-    // without buffering- maybe we could read the tar entries while streaming to disk,
-    // and then divide them among workers that apply them to disk concurrently?
-    while let Some(entry) = entries.next().await {
-        let mut entry = unwrap_warn!(entry, continue, "read entry");
-        let path = unwrap_warn!(entry.path(), continue, "read entry path");
-
-        // Paths inside the container are relative to the root of the container;
-        // we need to convert them to be relative to the output directory.
-        let path = output.join(path);
-
-        if !path_filters.matches(&path) {
-            debug!(?path, "skip: path filter");
-            continue;
-        }
-
-        // Whiteout files delete the file from the filesystem.
-        if let Some(path) = is_whiteout(&path) {
-            unwrap_warn!(
-                tokio::fs::remove_file(&path).await,
-                continue,
-                "whiteout: {path:?}"
-            );
-            debug!(?path, "whiteout");
-            continue;
-        }
-
-        // The tar library mostly handles symlinks properly, but still allows them to link to absolute paths.
-        // This doesn't technically break anything from a security standpoint, but might for analysis.
-        // Intercept its handling of absolute symlinks to handle this case.
-        if entry.header().entry_type().is_symlink() {
-            let handled = unwrap_warn!(
-                safe_symlink(&entry, output).await,
-                continue,
-                "create symlink {path:?}"
-            );
-
-            // But if the function didn't handle it, fall back to the default behavior.
-            if handled {
-                continue;
-            }
-        }
-
-        // Future improvement: symlinks are unpacked with the same destination as written in the actual container;
-        // this means e.g. they can link to files outside of the output directory
-        // (the example case I found was in `usr/bin`, linking to `/bin/`).
-        // I don't _think_ this matters for now given how we're using this today, but it's technically incorrect.
-        // To fix this we need to re-implement the logic in `unpack_in` to rewrite symlink destinations.
-
-        // Otherwise, apply the file as normal.
-        // Both _new_ and _changed_ files are handled the same way:
-        // the layer contains the entire file content, so we just overwrite the file.
-        if !unwrap_warn!(entry.unpack_in(output).await, continue, "unpack {path:?}") {
-            warn!(?path, "skip: tried to write outside of output directory");
-            continue;
-        }
-
-        debug!(?path, "apply");
-    }
-
-    Ok(())
-}
-
-/// Enumerate files in a tarball.
-async fn enumerate_tarball(stream: impl Stream<Item = Chunk> + Unpin) -> Result<Vec<String>> {
-    let reader = StreamReader::new(stream);
-    let mut archive = Archive::new(reader);
-    let mut entries = archive.entries().context("read entries from tar")?;
-
-    let mut files = Vec::new();
-    while let Some(entry) = entries.next().await {
-        let entry = unwrap_warn!(entry, continue, "read entry");
-        let path = unwrap_warn!(entry.path(), continue, "read entry path");
-        debug!(?path, "enumerate");
-        files.push(path.to_string_lossy().to_string());
-    }
-
-    Ok(files)
-}
-
-/// Special handling for symlinks that link to an absolute path.
-/// It effectively forces the destination into a path relative to the output directory.
-///
-/// Returns true if the symlink was handled;
-/// false if the symlink should fall back to standard handling from `async_tar`.
-async fn safe_symlink<R: AsyncRead + Unpin>(entry: &Entry<R>, dir: &Path) -> Result<bool> {
-    let header = entry.header();
-    let kind = header.entry_type();
-    if !kind.is_symlink() {
-        return Ok(false);
-    }
-
-    let link = entry.path().context("read symlink source")?;
-    let target = header
-        .link_name()
-        .context("read symlink target")?
-        .ok_or_eyre("no symlink target")?;
-
-    // If the target is relative, we should let `async_tar` handle it;
-    // this function only needs to intercept absolute symlinks.
-    if !target.is_absolute() {
-        return Ok(false);
-    }
-
-    let safe_link = dir.join(&link);
-    let safe_target = dir.join(strip_root(&target));
-
-    let rel_target = compute_symlink_target(&safe_link, &safe_target)
-        .with_context(|| format!("compute relative path from {safe_link:?} to {safe_target:?}"))?;
-    debug!(
-        ?link,
-        ?target,
-        ?safe_link,
-        ?safe_target,
-        ?rel_target,
-        "create symlink"
-    );
-
-    if let Some(parent) = safe_link.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .context("create parent directory")?;
-    }
-
-    symlink(&rel_target, &safe_link)
-        .await
-        .map(|_| true)
-        .with_context(|| {
-            format!("create symlink from {safe_link:?} to {safe_target:?} as {rel_target:?}")
-        })
-}
-
-fn compute_symlink_target(src: &Path, dst: &Path) -> Result<PathBuf> {
-    let common_prefix = src
-        .components()
-        .zip(dst.components())
-        .by_ref()
-        .take_while(|(src, dst)| src == dst)
-        .map(|(src, _)| src)
-        .collect::<PathBuf>();
-
-    let src_rel = src
-        .strip_prefix(&common_prefix)
-        .context("strip common prefix from src")?;
-    let dst_rel = dst
-        .strip_prefix(&common_prefix)
-        .context("strip common prefix from dst")?;
-
-    // `bridge` is the path from the source to the common prefix.
-    let bridge = src_rel
-        .components()
-        .skip(1)
-        .map(|_| "..")
-        .collect::<PathBuf>();
-    let rel = bridge.join(dst_rel);
-
-    // `.` indicates that the source and destination are the same file.
-    if rel.to_string_lossy().is_empty() {
-        Ok(PathBuf::from("."))
-    } else {
-        Ok(rel)
-    }
-}
-
-/// Strips any root and prefix from a path, if they exist.
-fn strip_root(path: impl AsRef<Path>) -> PathBuf {
-    path.as_ref()
-        .components()
-        .filter(|c| match c {
-            std::path::Component::Prefix(_) => false,
-            std::path::Component::RootDir => false,
-            _ => true,
-        })
-        .pipe(PathBuf::from_iter)
-}
-
-#[cfg(windows)]
-async fn symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
-    let (src, dst) = (src.to_owned(), dst.to_owned());
-    tokio::task::spawn_blocking(|| std::os::windows::fs::symlink_file(src, dst))
-        .await
-        .expect("join tokio task")
-}
-
-#[cfg(any(unix, target_os = "redox"))]
-async fn symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
-    tokio::fs::symlink(src, dst).await
-}
-
 impl From<&Reference> for OciReference {
     fn from(reference: &Reference) -> Self {
         match &reference.version {
-            Version::Tag(tag) => Self::with_tag(
-                reference.host.clone(),
-                reference.repository.clone(),
-                tag.clone(),
-            ),
+            Version::Tag(tag) => {
+                Self::with_tag(reference.host.clone(), reference.repository(), tag.clone())
+            }
             Version::Digest(digest) => Self::with_digest(
                 reference.host.clone(),
-                reference.repository.clone(),
+                reference.repository(),
                 digest.to_string(),
             ),
         }
@@ -692,20 +459,6 @@ impl FilterMatch<&PathBuf> for Filter {
     fn matches(&self, value: &PathBuf) -> bool {
         self.matches(value.to_string_lossy())
     }
-}
-
-/// Returns the path to the file that would be deleted by a whiteout file, if the path is a whiteout file.
-/// If the path is not a whiteout file, returns `None`.
-fn is_whiteout(path: &Path) -> Option<PathBuf> {
-    const WHITEOUT_PREFIX: &str = ".wh.";
-
-    // If the file doesn't have a name, it's not a whiteout file.
-    // Similarly if it doesn't have the prefix, it's also not a whiteout file.
-    let name = path.file_name()?.strip_prefix(WHITEOUT_PREFIX)?;
-    Some(match path.parent() {
-        Some(parent) => PathBuf::from(parent).join(name),
-        None => PathBuf::from(name),
-    })
 }
 
 fn client(platform: Option<Platform>) -> Client {
@@ -778,33 +531,5 @@ const fn go_arch() -> &'static str {
     #[cfg(target_arch = "aarch64")]
     {
         "arm64"
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use pretty_assertions::assert_eq;
-    use simple_test_case::test_case;
-
-    #[test]
-    fn test_is_whiteout() {
-        assert_eq!(None, is_whiteout(Path::new("foo")));
-        assert_eq!(
-            Some(PathBuf::from("foo")),
-            is_whiteout(Path::new(".wh.foo")),
-        );
-    }
-
-    #[test_case(Path::new("/a/b/c"), Path::new("/a/b/d/e/f"), PathBuf::from("d/e/f"); "one_level")]
-    #[test_case(Path::new("/usr/local/bin/ls"), Path::new("/bin/ls"), PathBuf::from("../../../bin/ls"); "usr_local_bin_to_bin")]
-    #[test_case(Path::new("/usr/local/bin/ls"), Path::new("/usr/bin/ls"), PathBuf::from("../../bin/ls"); "usr_local_bin_to_usr_bin")]
-    #[test_case(Path::new("/usr/local/bin/ls"), Path::new("/usr/local/bin/ls"), PathBuf::from("."); "same_file")]
-    #[test_case(Path::new("/usr/local/bin/eza"), Path::new("/usr/local/bin/ls"), PathBuf::from("ls"); "same_dir")]
-    #[tokio::test]
-    async fn compute_symlink_target(src: &Path, dst: &Path, expected: PathBuf) -> Result<()> {
-        let relative = compute_symlink_target(src, dst)?;
-        pretty_assertions::assert_eq!(expected, relative);
-        Ok(())
     }
 }

--- a/lib/src/registry.rs
+++ b/lib/src/registry.rs
@@ -77,6 +77,8 @@ impl Registry {
         /// The reference to use for the registry.
         reference: Reference,
     ) -> Result<Self> {
+        crate::flag_disabled_registry_oci()?;
+
         let client = client(platform.clone());
         let original = reference.clone();
         let reference = OciReference::from(&reference);

--- a/lib/src/registry.rs
+++ b/lib/src/registry.rs
@@ -27,7 +27,7 @@ use crate::{
     ext::PriorityFind,
     transform::{self, Chunk},
     Authentication, Digest, Filter, FilterMatch, Filters, Layer, LayerMediaType,
-    LayerMediaTypeFlag, Platform, Reference, Version,
+    LayerMediaTypeFlag, Platform, Reference, Source, Version,
 };
 
 /// Unwrap a value, logging an error and performing the provided action if it fails.
@@ -369,6 +369,36 @@ impl Registry {
                 }))
             }
         }
+    }
+}
+
+impl Source for Registry {
+    fn original(&self) -> &Reference {
+        &self.original
+    }
+
+    async fn layers(&self) -> Result<Vec<Layer>> {
+        self.layers().await
+    }
+
+    async fn digest(&self) -> Result<Digest> {
+        self.digest().await
+    }
+
+    async fn pull_layer(&self, layer: &Layer) -> Result<impl Stream<Item = Result<Bytes>>> {
+        self.pull_layer(layer).await
+    }
+
+    async fn list_files(&self, layer: &Layer) -> Result<Vec<String>> {
+        self.list_files(layer).await
+    }
+
+    async fn apply_layer(&self, layer: &Layer, output: &Path) -> Result<()> {
+        self.apply_layer(layer, output).await
+    }
+
+    async fn layer_plain_tarball(&self, layer: &Layer) -> Result<Option<TempFile>> {
+        self.layer_plain_tarball(layer).await
     }
 }
 

--- a/lib/src/testdata/nginx_manifest.json
+++ b/lib/src/testdata/nginx_manifest.json
@@ -1,0 +1,46 @@
+{
+  "config": {
+    "digest": "sha256:b52e0b094bc0e26c9eddc9e4ab7a64ce0033c3360d8b7ad4ff4132c4e03e8f7b",
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 8582
+  },
+  "layers": [
+    {
+      "digest": "sha256:5f1ee22ffb5e68686db3dcb6584eb1c73b5570615b0f14fabb070b96117e351d",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "size": 77844480
+    },
+    {
+      "digest": "sha256:c68632c455ae0c46d1380033bae6d30014853fa3f600f4e14efc440be1bc9580",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "size": 118268416
+    },
+    {
+      "digest": "sha256:cabea05c000e49f0814b2611cbc66c2787f609d8a27fc7b9e97b5dab5d8502da",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "size": 3584
+    },
+    {
+      "digest": "sha256:791f0a07985c2814a899cb0458802be06ba124a364f7e5a9413a1f08fdbf5b5c",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "size": 4608
+    },
+    {
+      "digest": "sha256:f6d5815f290ee912fd4a768d97b46af39523dff584d786f5c0f7e9bdb7fad537",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "size": 2560
+    },
+    {
+      "digest": "sha256:7d22e2347c1217a89bd3c79ca9adb4652c1e9b61427fffc0ab92227aacd19a38",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "size": 5120
+    },
+    {
+      "digest": "sha256:55e9644f21c38d7707b4a432aacc7817c5414b68ac7a750e704c2f7100ebc15c",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "size": 7168
+    }
+  ],
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "schemaVersion": 2
+}

--- a/lib/tests/it/docker.rs
+++ b/lib/tests/it/docker.rs
@@ -1,5 +1,5 @@
 use async_tempfile::TempDir;
-use circe_lib::{registry::Registry, Authentication, Reference};
+use circe_lib::{registry::Registry, Authentication, Reference, Source};
 use color_eyre::Result;
 use simple_test_case::test_case;
 

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -2,7 +2,7 @@ use async_tempfile::TempDir;
 use circe_lib::{
     extract::{extract, Report, Strategy},
     registry::Registry,
-    Digest, Reference,
+    Digest, Reference, Source,
 };
 use color_eyre::Result;
 use serde_json::{json, Value};

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -25,7 +25,6 @@ macro_rules! assert_layers_extracted {
 
 #[test_log::test(tokio::test)]
 async fn report_roundtrip() -> Result<()> {
-    let reference = Reference::from_str("cgr.dev/chainguard/wolfi-base:latest")?;
     let digest_img = Digest::from_str(
         "sha256:931040ffeedc9148b2ed852bc1a9531af141a6bc1f4761ea96c1f2c13b8b6659",
     )?;
@@ -37,8 +36,6 @@ async fn report_roundtrip() -> Result<()> {
     )?;
 
     let report = Report::builder()
-        .name("wolfi-base")
-        .reference(reference)
         .digest(digest_img.clone())
         .layers([
             (digest_layer_1.clone(), PathBuf::from("/tmp/layer1")),
@@ -95,14 +92,9 @@ async fn report(image: &str) -> Result<()> {
     .await?;
 
     let report = Report::builder()
-        .name(&registry.original.name)
-        .reference(&registry.original)
         .digest(registry.digest().await?)
         .layers(extracted)
         .build();
-
-    pretty_assertions::assert_eq!(report.name, registry.original.name);
-    pretty_assertions::assert_eq!(report.reference, registry.original);
 
     let actual_digest = registry.digest().await?;
     pretty_assertions::assert_eq!(report.digest, actual_digest.to_string());
@@ -135,8 +127,6 @@ async fn squash(image: &str) -> Result<()> {
 
     let extracted = extract(&registry, tmp.dir_path(), Strategy::Squash(layers)).await?;
     let report = Report::builder()
-        .name(&registry.original.name)
-        .reference(&registry.original)
         .digest(registry.digest().await?)
         .layers(extracted)
         .build();
@@ -169,8 +159,6 @@ async fn base(image: &str) -> Result<()> {
         .expect("image should have at least one layer");
     let extracted = extract(&registry, tmp.dir_path(), Strategy::Separate(base.clone())).await?;
     let report = Report::builder()
-        .name(&registry.original.name)
-        .reference(&registry.original)
         .digest(registry.digest().await?)
         .layers(extracted)
         .build();
@@ -204,8 +192,6 @@ async fn squash_other(image: &str) -> Result<()> {
     )
     .await?;
     let report = Report::builder()
-        .name(&registry.original.name)
-        .reference(&registry.original)
         .digest(registry.digest().await?)
         .layers(extracted)
         .build();
@@ -243,8 +229,6 @@ async fn base_and_squash_other(image: &str) -> Result<()> {
 
     let extracted = extract(&registry, tmp.dir_path(), strategies).await?;
     let report = Report::builder()
-        .name(&registry.original.name)
-        .reference(&registry.original)
         .digest(registry.digest().await?)
         .layers(extracted)
         .build();
@@ -280,8 +264,6 @@ async fn separate(image: &str) -> Result<()> {
 
     let extracted = extract(&registry, tmp.dir_path(), strategies).await?;
     let report = Report::builder()
-        .name(&registry.original.name)
-        .reference(&registry.original)
         .digest(registry.digest().await?)
         .layers(extracted)
         .build();

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -110,7 +110,7 @@ async fn report(image: &str) -> Result<()> {
 
     // Hard coded so that tests will notice if we accidentally change this path
     let path = tmp.dir_path().join("image.json");
-    report.write(&tmp.dir_path()).await?;
+    report.write(tmp.dir_path()).await?;
 
     let report_text = tokio::fs::read_to_string(&path).await?;
     pretty_assertions::assert_eq!(report_text, report.render()?);

--- a/lib/tests/it/extract.rs
+++ b/lib/tests/it/extract.rs
@@ -49,16 +49,7 @@ async fn report_roundtrip() -> Result<()> {
     pretty_assertions::assert_eq!(
         parsed,
         json!({
-            "name": "wolfi-base",
             "digest": digest_img.to_string(),
-            "reference": {
-                "host": "cgr.dev",
-                "repository": "chainguard/wolfi-base",
-                "version": {
-                    "kind": "tag",
-                    "value": "latest"
-                }
-            },
             "layers": [
                 [digest_layer_1.to_string(), "/tmp/layer1"],
                 [digest_layer_2.to_string(), "/tmp/layer2"],

--- a/lib/tests/it/reference.rs
+++ b/lib/tests/it/reference.rs
@@ -67,9 +67,9 @@ fn docker_like_custom_base_namespace(input: &str, expected: &str) {
     const REQUIRED_BASE: &str = "host.dev";
     const REQUIRED_NAMESPACE: &str = "somecorp/someproject";
     let base = std::env::var(circe_lib::OCI_BASE_VAR)
-        .expect(format!("'{}' must be set", circe_lib::OCI_BASE_VAR).as_str());
+        .unwrap_or_else(|_| panic!("'{}' must be set", circe_lib::OCI_BASE_VAR));
     let ns = std::env::var(circe_lib::OCI_NAMESPACE_VAR)
-        .expect(format!("'{}' must be set", circe_lib::OCI_NAMESPACE_VAR).as_str());
+        .unwrap_or_else(|_| panic!("'{}' must be set", circe_lib::OCI_NAMESPACE_VAR));
     pretty_assertions::assert_eq!(
         base,
         REQUIRED_BASE,

--- a/lib/tests/it/registry.rs
+++ b/lib/tests/it/registry.rs
@@ -1,6 +1,6 @@
 use async_tempfile::TempDir;
 use async_walkdir::WalkDir;
-use circe_lib::{registry::Registry, Filters, Platform, Reference};
+use circe_lib::{registry::Registry, Filters, Platform, Reference, Source};
 use color_eyre::Result;
 use simple_test_case::test_case;
 

--- a/lib/tests/it/registry.rs
+++ b/lib/tests/it/registry.rs
@@ -43,7 +43,8 @@ async fn pull_layer_filtered(
     let platform = Platform::linux_amd64();
     let reference = Reference::builder()
         .host("cgr.dev")
-        .repository("chainguard/wolfi-base")
+        .namespace("chainguard")
+        .name("wolfi-base")
         .tag("latest")
         .build();
 


### PR DESCRIPTION
# Overview

- Adds support for pulling images from the Docker daemon for `list`, `extract`, and `reexport`.
- Adds the concept of `Source`, a new abstraction over all sources.
- Adds the concept of "strategies" to subcommands.
- Tries strategies in order until one succeeds or all fail.

Note: This PR also removes some extra info from the `Report` type that isn't really compatible with non-OCI sources. Technically I could have made something work but FOSSA CLI isn't even going to use this `Report` type after all, and I'm not aware of Circe having any actual users other than FOSSA CLI, so I think it's safe to just remove.

## Acceptance criteria

The `extract`, `list`, and `reexport` subcommands support:
- pulling containers from the local docker daemon
- reading saved tarballs from disk

## Testing plan

Automated tests; new integration tests cover this functionality.

## Metrics

None

## Risks

Not really a risk, but `docker save` tarballs and docker daemon exports are only supported by Circe when they export _OCI compliant_ tarballs; older versions of Docker which only export in the legacy docker format _do not work with Circe_.

## References



## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
